### PR TITLE
j-log-engine: Cabrillo export now chronological (fix + SS Phone test)

### DIFF
--- a/j-log-engine/src/main/java/com/jlog/export/CabrilloExporter.java
+++ b/j-log-engine/src/main/java/com/jlog/export/CabrilloExporter.java
@@ -27,7 +27,16 @@ public class CabrilloExporter {
     private static final DateTimeFormatter CAB_TIME = DateTimeFormatter.ofPattern("HHmm");
 
     public static void export(ContestPlugin plugin, Path destination) throws Exception {
-        List<QsoRecord> qsos = ContestQsoDao.getInstance().fetchByContest(plugin.getContestId());
+        // fetchByContest sorts datetime_utc DESC for the cockpit UI
+        // ("newest at top"). Cabrillo sponsors want the log in chronological
+        // order, so re-sort ascending here. Nulls (corrupt rows missing a
+        // timestamp) trail at the end rather than throwing.
+        List<QsoRecord> qsos = ContestQsoDao.getInstance().fetchByContest(plugin.getContestId())
+            .stream()
+            .sorted(java.util.Comparator.comparing(
+                QsoRecord::getDateTimeUtc,
+                java.util.Comparator.nullsLast(java.util.Comparator.naturalOrder())))
+            .toList();
         AppConfig cfg = AppConfig.getInstance();
 
         // Lock UTF-8 explicitly — see comment in AdifExporter for rationale.

--- a/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterAllPluginsSmokeTest.java
+++ b/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterAllPluginsSmokeTest.java
@@ -1,0 +1,246 @@
+package com.jlog.export;
+
+import com.jlog.db.ContestQsoDao;
+import com.jlog.db.DatabaseManager;
+import com.jlog.db.ContestQtcDao;
+import com.jlog.model.QsoRecord;
+import com.jlog.plugin.ContestPlugin;
+import com.jlog.plugin.PluginLoader;
+import com.jlog.util.AppConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Smoke test for the Cabrillo exporter across every bundled contest plugin.
+ *
+ * For each plugin: wipe contest_qso, populate AppConfig with dummy values
+ * for any constant exchange fields (so the sponsor's robot would see filled
+ * tokens), insert 3 dummy QSOs whose field1..5 slots are filled per the
+ * plugin's own slot mapping, export to a temp .cbr, and assert the
+ * structural invariants the sponsor's robot checks first:
+ *
+ *   1. START-OF-LOG: 3.0 ... END-OF-LOG: envelope
+ *   2. CONTEST: &lt;id-with-dashes&gt; header
+ *   3. CALLSIGN: WM3J header
+ *   4. Exactly 3 QSO: lines (matches insert count)
+ *   5. Each QSO line is well-formed (starts with QSO:, contains mycall +
+ *      dxcall, has at least 9 whitespace-separated tokens so there's at
+ *      least 1 sent + 1 rcvd exchange token beyond the 7 fixed positions)
+ *   6. QSO lines appear in chronological order (dxcalls K1A, K2A, K3A
+ *      in insertion order) — pins the 1f59d2c chronological-sort fix
+ *
+ * Does NOT validate per-sponsor format quirks (token order, padding,
+ * specific category headers) — that's what the family deep-dive tests
+ * (like CabrilloExporterSsSsbTest) are for. This is the cheap broad
+ * net that catches crashes, slot-mapping bugs, blank exchanges, and
+ * order regressions across the whole 86-plugin catalog in one CI run.
+ */
+class CabrilloExporterAllPluginsSmokeTest {
+
+    /** Special entry-field ids that consume no field1..5 slot. Mirror of the
+     *  switch statement in {@link ContestPlugin#fieldSlotColumn(String)}. */
+    private static final Set<String> SPECIAL_NON_SLOT_IDS = Set.of(
+        "callsign", "serial_sent", "serial_rcvd", "band", "mode",
+        "rst_sent", "rst_rcvd", "prec_sent", "check_sent", "sect_sent"
+    );
+
+    // JUnit 5's @MethodSource (allPluginIds) is invoked during test
+    // discovery, BEFORE @BeforeAll. PluginLoader uses java.util.prefs to
+    // resolve the user-installed-plugins path, which throws NPE on a null
+    // user.home. Set user.home and bootstrap the loader here so the source
+    // sees a populated catalog before the test parameter list is built.
+    static {
+        try {
+            Path tmpHome = Files.createTempDirectory("jhub-cabrillo-smoke-");
+            tmpHome.toFile().deleteOnExit();
+            System.setProperty("user.home", tmpHome.toString());
+            // Order matters:
+            //   AppConfig.load() must run first — its prefs field is lazy
+            //     and the PluginLoader catalog filter calls
+            //     AppConfig.getHiddenContestIds() which dereferences it.
+            //   DatabaseManager.initAll() before PluginLoader.init() —
+            //     loadUserDir consults DatabaseManager.getDataDir().
+            AppConfig.getInstance().load();
+            DatabaseManager.getInstance().initAll();
+            PluginLoader.getInstance().init();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to bootstrap test fixtures", e);
+        }
+    }
+
+    @BeforeAll
+    static void initSuite() {
+        // Bootstrap happened in the static initializer above so the
+        // @MethodSource catalog is populated. Nothing to do per-suite.
+
+        AppConfig cfg = AppConfig.getInstance();
+        cfg.setStationCallsign("WM3J");
+        DatabaseManager.getInstance().setConfig("station.grid", "FM19");
+        DatabaseManager.getInstance().setConfig("cab.operator", "SINGLE-OP");
+        DatabaseManager.getInstance().setConfig("cab.band",     "ALL");
+        // Sweepstakes sent constants — only used by ARRL SS plugins, harmless
+        // for everything else (resolveField checks isConstant first).
+        cfg.setSsPrecedence("B");
+        cfg.setSsCheck("83");
+        cfg.setSsSection("MDC");
+    }
+
+    /** Provide every loaded plugin's contestId as a separate test invocation. */
+    static Stream<String> allPluginIds() {
+        return PluginLoader.getInstance().getAvailablePlugins().stream()
+            .map(ContestPlugin::getContestId)
+            .sorted();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("allPluginIds")
+    void cabrilloExportIsStructurallyValid(String contestId, @TempDir Path dir) throws Exception {
+        ContestPlugin plugin = PluginLoader.getInstance().getById(contestId);
+        assertNotNull(plugin, "plugin not loaded: " + contestId);
+
+        // Wipe contest_qso + contest_qtc so each plugin starts clean.
+        try (Statement st = DatabaseManager.getInstance().getContestConnection().createStatement()) {
+            st.executeUpdate("DELETE FROM contest_qso");
+            st.executeUpdate("DELETE FROM contest_qtc");
+        }
+        // Populate AppConfig for every constant entry field this plugin
+        // declares — resolveField pulls these via cfg.getContestConstant.
+        AppConfig cfg = AppConfig.getInstance();
+        if (plugin.getEntryFields() != null) {
+            for (ContestPlugin.FieldDef fd : plugin.getEntryFields()) {
+                if (fd.isConstant() && fd.getId() != null) {
+                    cfg.setContestConstant(contestId, fd.getId(), "X");
+                }
+            }
+        }
+
+        // Insert 3 QSOs with distinct callsigns (avoid dupe filtering).
+        LocalDateTime base = LocalDateTime.of(2026, 1, 1, 12, 0);
+        String[] dxCalls = { "K1A", "K2A", "K3A" };
+        for (int i = 0; i < 3; i++) {
+            QsoRecord q = buildDummyQso(plugin, dxCalls[i], i + 1, base.plusMinutes(i));
+            ContestQsoDao.getInstance().insert(q);
+        }
+        assertEquals(3, ContestQsoDao.getInstance().fetchByContest(contestId).size(),
+            "all 3 dummy QSOs must persist for " + contestId);
+
+        // Export.
+        Path out = dir.resolve(contestId + ".cbr");
+        try {
+            CabrilloExporter.export(plugin, out);
+        } catch (Exception e) {
+            fail("CabrilloExporter threw on " + contestId + ": " + e.getMessage(), e);
+        }
+        String cabrillo = Files.readString(out);
+        List<String> lines = cabrillo.lines().toList();
+
+        // --- Structural assertions ---
+        assertTrue(lines.size() > 5, "Cabrillo file suspiciously short for " + contestId
+            + ":\n" + cabrillo);
+        assertEquals("START-OF-LOG: 3.0", lines.get(0).trim(),
+            "first line must be Cabrillo 3.0 marker for " + contestId);
+
+        String expectedContestHeader = "CONTEST: " + contestId.replace("_", "-");
+        assertTrue(cabrillo.contains(expectedContestHeader),
+            "missing '" + expectedContestHeader + "' header for " + contestId);
+        assertTrue(cabrillo.contains("CALLSIGN: WM3J"),
+            "missing CALLSIGN: WM3J header for " + contestId);
+        assertTrue(cabrillo.contains("END-OF-LOG:"),
+            "missing END-OF-LOG: terminator for " + contestId);
+
+        List<String> qsoLines = lines.stream().filter(l -> l.startsWith("QSO:")).toList();
+        assertEquals(3, qsoLines.size(),
+            "expected 3 QSO: lines for " + contestId + " but got " + qsoLines.size()
+            + "\n--- Cabrillo dump ---\n" + cabrillo);
+
+        // Per-QSO checks.
+        for (int i = 0; i < 3; i++) {
+            String line = qsoLines.get(i);
+            String dx = dxCalls[i];
+            assertTrue(line.contains("WM3J"),
+                "QSO line for " + contestId + " missing our callsign:\n" + line);
+            assertTrue(line.contains(dx),
+                "QSO line " + i + " for " + contestId + " missing dxcall " + dx + ":\n" + line);
+
+            String[] tokens = line.trim().split("\\s+");
+            // QSO: freq mode date time mycall <sent...> dxcall <rcvd...>
+            // 7 fixed tokens; we want at least 1 sent + 1 rcvd token beyond that.
+            assertTrue(tokens.length >= 9,
+                "QSO line for " + contestId + " has only " + tokens.length
+                + " tokens (need >= 9 for non-empty exchanges):\n" + line);
+
+            // No literal "null" placeholders bleeding through resolveField.
+            assertFalse(line.matches(".*\\bnull\\b.*"),
+                "QSO line for " + contestId + " contains literal 'null':\n" + line);
+        }
+
+        // Chronological ordering — dxcalls must appear in K1A, K2A, K3A order.
+        for (int i = 0; i < 3; i++) {
+            assertTrue(qsoLines.get(i).contains(dxCalls[i]),
+                "chronological order broken for " + contestId
+                + ": QSO line " + i + " should mention " + dxCalls[i] + " but is:\n"
+                + qsoLines.get(i));
+        }
+    }
+
+    /** Build a dummy QSO with field1..5 slots populated per the plugin's
+     *  own slot mapping. The slot value is "X<slot>" so a regression that
+     *  swaps two fields is visible in the Cabrillo dump. */
+    private static QsoRecord buildDummyQso(ContestPlugin plugin, String dxCall,
+                                            int serial, LocalDateTime when) {
+        QsoRecord q = new QsoRecord();
+        q.setContestId(plugin.getContestId());
+        q.setCallsign(dxCall);
+        q.setDateTimeUtc(when);
+        q.setBand("20m");
+        q.setMode("SSB");
+        q.setFrequency("14250");
+        q.setSerialSent(Integer.toString(serial));
+        q.setSerialReceived(Integer.toString(serial + 10));
+        q.setRstSent("59");
+        q.setRstReceived("59");
+        q.setPoints(1);
+
+        // Fill every slot the plugin declares with "X<slot>" so blank exchanges
+        // and slot-swap regressions are visible. The slot assignment must
+        // mirror ContestPlugin.fieldSlotColumn exactly.
+        int slot = 0;
+        Set<String> assigned = new HashSet<>();
+        if (plugin.getEntryFields() != null) {
+            for (ContestPlugin.FieldDef fd : plugin.getEntryFields()) {
+                if (fd.isConstant()) continue;
+                String id = fd.getId();
+                if (id == null || SPECIAL_NON_SLOT_IDS.contains(id)) continue;
+                if (slot >= 5) break;
+                String value = "X" + (slot + 1);
+                switch (slot) {
+                    case 0 -> q.setContestField1(value);
+                    case 1 -> q.setContestField2(value);
+                    case 2 -> q.setContestField3(value);
+                    case 3 -> q.setContestField4(value);
+                    case 4 -> q.setContestField5(value);
+                }
+                assigned.add(id);
+                slot++;
+            }
+        }
+        return q;
+    }
+}

--- a/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterArrlDxTest.java
+++ b/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterArrlDxTest.java
@@ -1,0 +1,148 @@
+package com.jlog.export;
+
+import com.jlog.db.ContestQsoDao;
+import com.jlog.db.DatabaseManager;
+import com.jlog.model.QsoRecord;
+import com.jlog.plugin.ContestPlugin;
+import com.jlog.plugin.PluginLoader;
+import com.jlog.util.AppConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Realistic Cabrillo export check for ARRL International DX, W/VE side
+ * (SSB variant). Asymmetric contest: W/VE stations send signal report +
+ * state/province; DX stations send signal report + power.
+ *
+ * Plugin spec:
+ *   cabrilloSent: ["rst_sent", "field3"]   — field3 = state_sent (PA)
+ *   cabrilloRcvd: ["rst_rcvd", "field2"]   — field2 = power_rcvd (100)
+ *
+ * Slot mapping (per ContestPlugin.fieldSlotColumn order over entryFields):
+ *   dxcc → field1, power_rcvd → field2, state_sent → field3
+ *
+ * Expected QSO line shape:
+ *   QSO: 14245 PH 2026-02-21 1500 WM3J 59 PA <DXCALL> 59 <PWR>
+ */
+class CabrilloExporterArrlDxTest {
+
+    @BeforeAll
+    static void initDb(@TempDir Path tmpHome) throws Exception {
+        System.setProperty("user.home", tmpHome.toString());
+        AppConfig.getInstance().load();
+        DatabaseManager.getInstance().initAll();
+        PluginLoader.getInstance().init();
+    }
+
+    @BeforeEach
+    void wipeContestQso() throws Exception {
+        try (Statement st = DatabaseManager.getInstance().getContestConnection().createStatement()) {
+            st.executeUpdate("DELETE FROM contest_qso");
+        }
+    }
+
+    @Test
+    void exportsTenQsoArrlDxSsbWveLogToWellFormedCabrillo(@TempDir Path dir) throws Exception {
+        ContestPlugin plugin = PluginLoader.getInstance().getById("ARRL_DX_SSB_US");
+        assertNotNull(plugin, "ARRL_DX_SSB_US plugin must be loaded");
+
+        AppConfig cfg = AppConfig.getInstance();
+        cfg.setStationCallsign("WM3J");
+        DatabaseManager.getInstance().setConfig("station.grid",   "FM19");
+        DatabaseManager.getInstance().setConfig("cab.operator",   "SINGLE-OP");
+        DatabaseManager.getInstance().setConfig("cab.band",       "ALL");
+
+        // Ten QSOs across bands, with realistic DX-side data.
+        // dxCall   prec  band   freq   pwrRcvd  dxccCountry        minute-offset
+        Object[][] data = {
+            {"DL5XX",  "20m", "14245",  "1KW",   "Germany",         0},
+            {"G3ABC",  "20m", "14245",  "400",   "England",         3},
+            {"F5RAB",  "20m", "14245",  "100",   "France",          7},
+            {"JA1ZZ",  "15m", "21245",  "100",   "Japan",          90},
+            {"VK3XY",  "15m", "21245",  "1500",  "Australia",     140},
+            {"ZL2AA",  "15m", "21245",  "300",   "New Zealand",   160},
+            {"PY2BB",  "10m", "28425",  "100",   "Brazil",        320},
+            {"LU5DX",  "10m", "28425",  "750",   "Argentina",     345},
+            {"OH2BH",  "40m", "7245",  "1500",   "Finland",      1200},
+            {"S52BT",  "40m", "7245",  "200",    "Slovenia",     1230},
+        };
+
+        LocalDateTime base = LocalDateTime.of(2026, 2, 21, 15, 0);
+        for (Object[] row : data) {
+            QsoRecord q = new QsoRecord();
+            q.setContestId(plugin.getContestId());
+            q.setCallsign((String) row[0]);
+            q.setBand((String) row[1]);
+            q.setFrequency((String) row[2]);
+            q.setMode("SSB");
+            q.setDateTimeUtc(base.plusMinutes((Integer) row[5]));
+            q.setRstSent("59");
+            q.setRstReceived("59");
+            q.setContestField1((String) row[4]);   // dxcc — needed for scoring
+            q.setContestField2((String) row[3]);   // power_rcvd
+            q.setContestField3("PA");              // state_sent (operator's state)
+            q.setPoints(3);                        // ARRL DX: 3 pts per QSO
+            ContestQsoDao.getInstance().insert(q);
+        }
+        assertEquals(10, ContestQsoDao.getInstance().fetchByContest("ARRL_DX_SSB_US").size());
+
+        Path out = dir.resolve("WM3J-arrl-dx-ssb.cbr");
+        CabrilloExporter.export(plugin, out);
+
+        String cabrillo = Files.readString(out);
+        System.out.println("\n=== Generated Cabrillo (" + out.getFileName() + ") ===");
+        System.out.println(cabrillo);
+        System.out.println("=== end ===\n");
+
+        List<String> lines = cabrillo.lines().toList();
+        assertEquals("START-OF-LOG: 3.0", lines.get(0).trim());
+        // KNOWN-WRONG (2026-05-28 finding): CONTEST: ARRL-DX-SSB-US is our
+        // internal split-side disambiguation; the ARRL robot expects
+        // "ARRL-DX-SSB" regardless of W/VE-vs-DX side (the operator
+        // category tells the sponsor which side). Pinned here as the
+        // current behavior; the planned Cabrillo header-correctness pass
+        // will flip this assertion to "ARRL-DX-SSB" once the exporter
+        // honors a per-plugin cabrilloContestName override. Affects
+        // ARRL_DX_*_US/DX (4 plugins) + likely ARRL_RRU_* (3 plugins).
+        assertTrue(cabrillo.contains("CONTEST: ARRL-DX-SSB-US"),
+            "header currently emits ARRL-DX-SSB-US (sponsor expects ARRL-DX-SSB)");
+        assertTrue(cabrillo.contains("CALLSIGN: WM3J"));
+        assertTrue(cabrillo.contains("END-OF-LOG:"));
+
+        List<String> qsoLines = lines.stream().filter(l -> l.startsWith("QSO:")).toList();
+        assertEquals(10, qsoLines.size(), "every inserted QSO must produce a QSO: line");
+
+        // Spot-check first QSO: WM3J 59 PA DL5XX 59 1KW (no serial in ARRL DX).
+        String first = qsoLines.get(0);
+        assertTrue(first.contains("WM3J"),  "WM3J in first QSO");
+        assertTrue(first.contains("DL5XX"), "DL5XX in first QSO");
+        assertTrue(first.contains(" 59 "),  "first QSO must contain RST tokens");
+        assertTrue(first.contains(" PA "),  "first QSO must show our state PA in sent exchange");
+        assertTrue(first.contains(" 1KW"),  "first QSO must show DL5XX's power 1KW in rcvd exchange");
+
+        // Chronological order: first inserted DL5XX should be line 1, last
+        // inserted S52BT should be line 10. Pins the 1f59d2c sort fix.
+        assertTrue(qsoLines.get(0).contains("DL5XX"),
+            "first QSO line should be the first-inserted DL5XX, got: " + qsoLines.get(0));
+        assertTrue(qsoLines.get(9).contains("S52BT"),
+            "last QSO line should be the last-inserted S52BT, got: " + qsoLines.get(9));
+
+        // ARRL DX has no serial number in the exchange — spot-check we didn't
+        // accidentally inject one. A bogus serial would appear right after
+        // WM3J like "WM3J 1 59 PA ...".
+        assertTrue(first.matches(".*WM3J\\s+59\\s+PA.*"),
+            "sent exchange should be just '59 PA' after mycall — no serial: " + first);
+    }
+}

--- a/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterArrlRttyRuTest.java
+++ b/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterArrlRttyRuTest.java
@@ -1,0 +1,148 @@
+package com.jlog.export;
+
+import com.jlog.db.ContestQsoDao;
+import com.jlog.db.DatabaseManager;
+import com.jlog.model.QsoRecord;
+import com.jlog.plugin.ContestPlugin;
+import com.jlog.plugin.PluginLoader;
+import com.jlog.util.AppConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Realistic Cabrillo export check for ARRL RTTY Roundup. Single-mode
+ * (RTTY) contest with mixed-shape exchange — W/VE stations send RST +
+ * state/province; DX stations send RST + serial. The receiver records
+ * whatever the other side sent in the same field.
+ *
+ * Plugin spec:
+ *   cabrilloSent: ["rst_sent", "field2"]   — field2 = state_prov_sent (PA)
+ *   cabrilloRcvd: ["rst_rcvd", "field1"]   — field1 = state_prov_rcvd
+ *                                            (state/prov OR serial)
+ *
+ * Slot mapping: state_prov_rcvd → field1, state_prov_sent → field2
+ *
+ * Expected QSO line shape:
+ *   QSO: <freq> RY <date> <time> <mycall> 599 PA <dxcall> 599 <st-or-ser>
+ */
+class CabrilloExporterArrlRttyRuTest {
+
+    @BeforeAll
+    static void initDb(@TempDir Path tmpHome) throws Exception {
+        System.setProperty("user.home", tmpHome.toString());
+        AppConfig.getInstance().load();
+        DatabaseManager.getInstance().initAll();
+        PluginLoader.getInstance().init();
+    }
+
+    @BeforeEach
+    void wipeContestQso() throws Exception {
+        try (Statement st = DatabaseManager.getInstance().getContestConnection().createStatement()) {
+            st.executeUpdate("DELETE FROM contest_qso");
+        }
+    }
+
+    @Test
+    void exportsRttyRoundupLogToWellFormedCabrillo(@TempDir Path dir) throws Exception {
+        ContestPlugin plugin = PluginLoader.getInstance().getById("ARRL_RTTY_RU");
+        assertNotNull(plugin, "ARRL_RTTY_RU plugin must be loaded");
+
+        AppConfig cfg = AppConfig.getInstance();
+        cfg.setStationCallsign("WM3J");
+        DatabaseManager.getInstance().setConfig("station.grid", "FM19");
+        DatabaseManager.getInstance().setConfig("cab.operator", "SINGLE-OP");
+        DatabaseManager.getInstance().setConfig("cab.band",     "ALL");
+
+        // 10 QSOs mixing W/VE (state/prov received) and DX (serial received).
+        // dxCall  band  freq    rcvdToken  isDx  minute
+        Object[][] data = {
+            {"K1AR",  "20m", "14080",  "CT",  false,   0},
+            {"W4PA",  "20m", "14080",  "TN",  false,   3},
+            {"N6TR",  "20m", "14080",  "OR",  false,   7},
+            {"VE3CC", "20m", "14080",  "ONS", false,  10},
+            {"DL5XX", "20m", "14080",  "001",  true,  15},
+            {"G3ABC", "20m", "14080",  "045",  true,  20},
+            {"JA1ZZ", "15m", "21080",  "112",  true, 140},
+            {"K0FX",  "15m", "21080",  "MN",  false, 165},
+            {"K3LR",  "40m", "7080",  "WPA",  false, 480},
+            {"VK3XY", "40m", "7080",  "201",   true, 510},
+        };
+
+        LocalDateTime base = LocalDateTime.of(2026, 1, 3, 18, 0);   // RTTY RU first Sat of Jan 1800Z
+        for (Object[] row : data) {
+            QsoRecord q = new QsoRecord();
+            q.setContestId(plugin.getContestId());
+            q.setCallsign((String) row[0]);
+            q.setBand((String) row[1]);
+            q.setFrequency((String) row[2]);
+            q.setMode("RTTY");
+            q.setRstSent("599");
+            q.setRstReceived("599");
+            q.setContestField1((String) row[3]);    // state_prov_rcvd OR serial
+            q.setContestField2("PA");                // state_prov_sent (operator's state)
+            q.setDateTimeUtc(base.plusMinutes((Integer) row[5]));
+            q.setPoints(2);                          // RTTY RU: 2 pts per QSO
+            ContestQsoDao.getInstance().insert(q);
+        }
+        assertEquals(10, ContestQsoDao.getInstance().fetchByContest("ARRL_RTTY_RU").size());
+
+        Path out = dir.resolve("WM3J-arrl-rtty-ru.cbr");
+        CabrilloExporter.export(plugin, out);
+
+        String cabrillo = Files.readString(out);
+        System.out.println("\n=== Generated Cabrillo (" + out.getFileName() + ") ===");
+        System.out.println(cabrillo);
+        System.out.println("=== end ===\n");
+
+        List<String> lines = cabrillo.lines().toList();
+        assertEquals("START-OF-LOG: 3.0", lines.get(0).trim());
+        assertTrue(cabrillo.contains("CONTEST: ARRL-RTTY-RU"),
+            "header must declare CONTEST: ARRL-RTTY-RU");
+        assertTrue(cabrillo.contains("CALLSIGN: WM3J"));
+        assertTrue(cabrillo.contains("END-OF-LOG:"));
+
+        List<String> qsoLines = lines.stream().filter(l -> l.startsWith("QSO:")).toList();
+        assertEquals(10, qsoLines.size(), "every inserted QSO must produce a QSO: line");
+
+        // Mode column for RTTY: should be "RY" (Cabrillo's RTTY token).
+        // The mode is the third whitespace-separated token in a QSO line.
+        for (String l : qsoLines) {
+            String mode = l.trim().split("\\s+")[2];
+            assertEquals("RY", mode,
+                "RTTY mode should map to Cabrillo 'RY' token, got '" + mode + "' in: " + l);
+        }
+
+        // Sent exchange must be "599 PA" on every QSO.
+        for (String l : qsoLines) {
+            assertTrue(l.matches(".*WM3J\\s+599\\s+PA\\s+.*"),
+                "every QSO sent half must be '599 PA': " + l);
+        }
+
+        // First QSO rcvd half: W/VE — "599 CT"
+        String first = qsoLines.get(0);
+        assertTrue(first.matches(".*K1AR\\s+599\\s+CT\\b.*"),
+            "first QSO rcvd half must be '599 CT': " + first);
+
+        // DX QSO rcvd half: serial e.g. "599 001"
+        String dxLine = qsoLines.stream().filter(l -> l.contains("DL5XX")).findFirst()
+            .orElseThrow(() -> new AssertionError("no DL5XX line in:\n" + cabrillo));
+        assertTrue(dxLine.matches(".*DL5XX\\s+599\\s+001\\b.*"),
+            "DX rcvd half must be '599 001' (serial from DX side): " + dxLine);
+
+        // Chronological order.
+        assertTrue(qsoLines.get(0).contains("K1AR"));
+        assertTrue(qsoLines.get(9).contains("VK3XY"));
+    }
+}

--- a/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterArrlVhfJuneTest.java
+++ b/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterArrlVhfJuneTest.java
@@ -1,0 +1,146 @@
+package com.jlog.export;
+
+import com.jlog.db.ContestQsoDao;
+import com.jlog.db.DatabaseManager;
+import com.jlog.model.QsoRecord;
+import com.jlog.plugin.ContestPlugin;
+import com.jlog.plugin.PluginLoader;
+import com.jlog.util.AppConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Realistic Cabrillo export check for ARRL June VHF — representative
+ * of the VHF/UHF/grid family (also covers Jan VHF + Sep VHF + 222 & Up
+ * + 10 GHz & Up + EME with minor exchange differences).
+ *
+ * Exchange shape:
+ *   Both sides send 4-char Maidenhead grid (e.g. FN10, FM19). No RST,
+ *   no serial. That's the entire exchange.
+ *
+ * Plugin spec:
+ *   cabrilloSent: ["grid_sent"]   → field2 = grid_sent (operator's grid)
+ *   cabrilloRcvd: ["grid_rcvd"]   → field1 = grid_rcvd
+ *
+ * Slot mapping: grid_rcvd → field1, grid_sent → field2.
+ *
+ * Expected QSO line shape (sponsor: ARRL VHF):
+ *   QSO: <freq-khz> <mode> <date> <time> <mycall> <ourGrid> <dxcall> <theirGrid>
+ *
+ * Note: VHF Cabrillo uses freq in kHz (e.g. 50125 for 6m) but spec
+ * also accepts the band tag.
+ */
+class CabrilloExporterArrlVhfJuneTest {
+
+    @BeforeAll
+    static void initDb(@TempDir Path tmpHome) throws Exception {
+        System.setProperty("user.home", tmpHome.toString());
+        AppConfig.getInstance().load();
+        DatabaseManager.getInstance().initAll();
+        PluginLoader.getInstance().init();
+    }
+
+    @BeforeEach
+    void wipeContestQso() throws Exception {
+        try (Statement st = DatabaseManager.getInstance().getContestConnection().createStatement()) {
+            st.executeUpdate("DELETE FROM contest_qso");
+        }
+    }
+
+    @Test
+    void exportsArrlJuneVhfLogToWellFormedCabrillo(@TempDir Path dir) throws Exception {
+        ContestPlugin plugin = PluginLoader.getInstance().getById("ARRL_VHF_JUNE");
+        assertNotNull(plugin, "ARRL_VHF_JUNE plugin must be loaded");
+
+        AppConfig cfg = AppConfig.getInstance();
+        cfg.setStationCallsign("WM3J");
+        DatabaseManager.getInstance().setConfig("station.grid", "FM19");
+        DatabaseManager.getInstance().setConfig("cab.operator", "SINGLE-OP");
+        DatabaseManager.getInstance().setConfig("cab.band",     "ALL");
+
+        // 10 QSOs across 6m + 2m + 70cm + 23cm + 10GHz. Different grids
+        // for multiplier diversity.
+        // dxCall    band    freq    mode    grid    pts  minute
+        Object[][] data = {
+            {"W3SO",  "6m",   "50125",  "SSB", "FN00",  1,    0},
+            {"K3IPM", "6m",   "50125",  "SSB", "FM18",  1,    5},
+            {"N3RG",  "6m",   "50313",  "FT8", "FM19",  1,   20},
+            {"K1TR",  "6m",   "50313",  "FT8", "FN42",  1,   40},
+            {"W1QA",  "2m",   "144250", "SSB", "FN42",  1,   90},
+            {"W3GAD", "2m",   "144175", "CW",  "FM19",  1,  150},
+            {"W3IP",  "70cm", "432100", "SSB", "FM19",  2,  210},
+            {"N3HBX", "70cm", "432100", "SSB", "FM19",  2,  240},
+            {"WA3EHD","23cm", "1296100","SSB", "FM19",  3,  300},
+            {"K1RZ",  "10GHz","10368100","SSB","FM19",  8,  720},
+        };
+
+        LocalDateTime base = LocalDateTime.of(2026, 6, 13, 18, 0);   // June VHF 2nd full Jun weekend Sat 1800Z
+        for (Object[] row : data) {
+            QsoRecord q = new QsoRecord();
+            q.setContestId(plugin.getContestId());
+            q.setCallsign((String) row[0]);
+            q.setBand((String) row[1]);
+            q.setFrequency((String) row[2]);
+            q.setMode((String) row[3]);
+            q.setContestField1((String) row[4]);   // grid_rcvd
+            q.setContestField2("FM19");             // grid_sent (operator's grid)
+            q.setDateTimeUtc(base.plusMinutes((Integer) row[6]));
+            q.setPoints((Integer) row[5]);
+            ContestQsoDao.getInstance().insert(q);
+        }
+        assertEquals(10, ContestQsoDao.getInstance().fetchByContest("ARRL_VHF_JUNE").size());
+
+        Path out = dir.resolve("WM3J-arrl-vhf-june.cbr");
+        CabrilloExporter.export(plugin, out);
+
+        String cabrillo = Files.readString(out);
+        System.out.println("\n=== Generated Cabrillo (" + out.getFileName() + ") ===");
+        System.out.println(cabrillo);
+        System.out.println("=== end ===\n");
+
+        List<String> lines = cabrillo.lines().toList();
+        assertEquals("START-OF-LOG: 3.0", lines.get(0).trim());
+        assertTrue(cabrillo.contains("CONTEST: ARRL-VHF-JUNE"),
+            "header must declare CONTEST: ARRL-VHF-JUNE");
+        assertTrue(cabrillo.contains("CALLSIGN: WM3J"));
+        assertTrue(cabrillo.contains("END-OF-LOG:"));
+
+        List<String> qsoLines = lines.stream().filter(l -> l.startsWith("QSO:")).toList();
+        assertEquals(10, qsoLines.size());
+
+        // Every QSO sent half must be just "FM19" (no RST, no serial).
+        // Expected layout: QSO: freq mode date time mycall FM19 dxcall theirGrid
+        // Token index: 0=QSO: 1=freq 2=mode 3=date 4=time 5=mycall 6=sent-grid 7=dxcall 8=rcvd-grid
+        for (String l : qsoLines) {
+            String[] tok = l.trim().split("\\s+");
+            assertEquals(9, tok.length,
+                "VHF QSO line should have exactly 9 tokens (no RST/serial): " + l);
+            assertEquals("FM19", tok[6],
+                "token 6 must be our sent grid FM19: " + l);
+            assertTrue(tok[8].matches("[A-R]{2}\\d{2}"),
+                "token 8 must be a valid 4-char grid: " + l);
+        }
+
+        // First QSO spot-check: WM3J FM19 W3SO FN00 on 6m.
+        String first = qsoLines.get(0);
+        assertTrue(first.contains("W3SO"));
+        assertTrue(first.matches(".*WM3J\\s+FM19\\s+W3SO\\s+FN00\\s*$"),
+            "first QSO exact layout 'mycall FM19 dxcall grid': " + first);
+
+        // Chronological.
+        assertTrue(qsoLines.get(0).contains("W3SO"));
+        assertTrue(qsoLines.get(9).contains("K1RZ"));
+    }
+}

--- a/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterCqWpxTest.java
+++ b/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterCqWpxTest.java
@@ -1,0 +1,157 @@
+package com.jlog.export;
+
+import com.jlog.db.ContestQsoDao;
+import com.jlog.db.DatabaseManager;
+import com.jlog.model.QsoRecord;
+import com.jlog.plugin.ContestPlugin;
+import com.jlog.plugin.PluginLoader;
+import com.jlog.util.AppConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Realistic Cabrillo export check for CQ WPX SSB. Exchange is RS +
+ * serial (e.g. "59 001"). Multiplier is the distinct WPX prefix across
+ * the entire contest (not per-band like CQ WW). Points by continent ×
+ * band group: HF (20/15/10) vs LF (160/80/40) and same-continent vs
+ * different-continent.
+ *
+ * Plugin spec:
+ *   cabrilloSent: ["rst_sent", "serial_sent"]   — both special, no slots
+ *   cabrilloRcvd: ["rst_rcvd", "serial_rcvd"]   — both special, no slots
+ *
+ * Slot mapping is trivial — every exchange field is in the
+ * special-non-slot set. No field1..5 needed.
+ *
+ * Expected QSO line shape (sponsor: CQ):
+ *   QSO: <freq> <mode> <date> <time> <mycall> 59 <ourSer> <dxcall> 59 <theirSer>
+ */
+class CabrilloExporterCqWpxTest {
+
+    @BeforeAll
+    static void initDb(@TempDir Path tmpHome) throws Exception {
+        System.setProperty("user.home", tmpHome.toString());
+        AppConfig.getInstance().load();
+        DatabaseManager.getInstance().initAll();
+        PluginLoader.getInstance().init();
+    }
+
+    @BeforeEach
+    void wipeContestQso() throws Exception {
+        try (Statement st = DatabaseManager.getInstance().getContestConnection().createStatement()) {
+            st.executeUpdate("DELETE FROM contest_qso");
+        }
+    }
+
+    @Test
+    void exportsTwelveQsoCqWpxSsbLogToWellFormedCabrillo(@TempDir Path dir) throws Exception {
+        ContestPlugin plugin = PluginLoader.getInstance().getById("CQ_WPX_SSB");
+        assertNotNull(plugin, "CQ_WPX_SSB plugin must be loaded");
+
+        AppConfig cfg = AppConfig.getInstance();
+        cfg.setStationCallsign("WM3J");
+        DatabaseManager.getInstance().setConfig("station.grid", "FM19");
+        DatabaseManager.getInstance().setConfig("cab.operator", "SINGLE-OP");
+        DatabaseManager.getInstance().setConfig("cab.band",     "ALL");
+
+        // 12 QSOs with distinct WPX prefixes so the contest-wide mult
+        // grows linearly. Prefixes: DL5, G3, F5, OH2, JA1, VK3, ZL2,
+        // PY2, LU5, OH1, S52, K1.
+        // dxCall  band  freq    pts (HF=3 DX-EU/3 DX-other/1 NA-NA, LF doubles)
+        // Per CQ WPX:
+        //   28/21/14 same-continent = 1 pt, different-continent = 3 pts
+        //   7/3.5/1.8 same-continent = 2 pts, different-continent = 6 pts
+        //   NA → NA = 1 pt (HF) / 2 pts (LF)
+        Object[][] data = {
+            // dxCall    band   freq    serRcvd  pts  minute
+            {"DL5XX",  "20m", "14245",  "045",    3,    0},
+            {"G3ABC",  "20m", "14245",  "112",    3,    3},
+            {"F5RAB",  "20m", "14245",  "008",    3,    7},
+            {"OH2BH",  "20m", "14245",  "234",    3,   12},
+            {"JA1ZZ",  "15m", "21245",  "067",    3,  120},
+            {"VK3XY",  "15m", "21245",  "199",    3,  140},
+            {"ZL2AA",  "15m", "21245",  "088",    3,  155},
+            {"PY2BB",  "10m", "28425",  "022",    3,  280},
+            {"LU5DX",  "10m", "28425",  "311",    3,  295},
+            {"OH1BB",  "10m", "28425",  "501",    3,  310},     // OH1 vs OH2 = distinct prefix
+            {"S52BT",  "40m", "7245",  "144",    6,   720},     // LF, different continent
+            {"K1AR",   "40m", "7245",  "298",    2,   750},     // LF, same continent
+        };
+
+        LocalDateTime base = LocalDateTime.of(2026, 3, 28, 0, 0);    // CQ WPX SSB last full Mar weekend
+        for (int i = 0; i < data.length; i++) {
+            Object[] row = data[i];
+            QsoRecord q = new QsoRecord();
+            q.setContestId(plugin.getContestId());
+            q.setCallsign((String) row[0]);
+            q.setBand((String) row[1]);
+            q.setFrequency((String) row[2]);
+            q.setMode("SSB");
+            q.setRstSent("59");
+            q.setRstReceived("59");
+            q.setSerialSent(String.format("%03d", i + 1));
+            q.setSerialReceived((String) row[3]);
+            q.setDateTimeUtc(base.plusMinutes((Integer) row[5]));
+            q.setPoints((Integer) row[4]);
+            ContestQsoDao.getInstance().insert(q);
+        }
+        assertEquals(12, ContestQsoDao.getInstance().fetchByContest("CQ_WPX_SSB").size());
+
+        Path out = dir.resolve("WM3J-cq-wpx-ssb.cbr");
+        CabrilloExporter.export(plugin, out);
+
+        String cabrillo = Files.readString(out);
+        System.out.println("\n=== Generated Cabrillo (" + out.getFileName() + ") ===");
+        System.out.println(cabrillo);
+        System.out.println("=== end ===\n");
+
+        List<String> lines = cabrillo.lines().toList();
+        assertEquals("START-OF-LOG: 3.0", lines.get(0).trim());
+        assertTrue(cabrillo.contains("CONTEST: CQ-WPX-SSB"),
+            "header must declare CONTEST: CQ-WPX-SSB");
+        assertTrue(cabrillo.contains("CALLSIGN: WM3J"));
+        assertTrue(cabrillo.contains("END-OF-LOG:"));
+
+        List<String> qsoLines = lines.stream().filter(l -> l.startsWith("QSO:")).toList();
+        assertEquals(12, qsoLines.size(), "every inserted QSO must produce a QSO: line");
+
+        // First QSO: WM3J 59 001 DL5XX 59 045.
+        String first = qsoLines.get(0);
+        assertTrue(first.contains("WM3J"));
+        assertTrue(first.contains("DL5XX"));
+        assertTrue(first.matches(".*WM3J\\s+59\\s+001\\s+.*"),
+            "first QSO sent half must be '59 001': " + first);
+        assertTrue(first.matches(".*DL5XX\\s+59\\s+045\\b.*"),
+            "first QSO rcvd half must be '59 045': " + first);
+
+        // Sent serials must increment 1..12 in chronological order — pins
+        // both the chronological-sort fix and the controller-side serial
+        // assignment. Captures the 3rd whitespace-separated token after
+        // mycall, which is the sent serial.
+        for (int i = 0; i < 12; i++) {
+            String l = qsoLines.get(i);
+            String[] tok = l.trim().split("\\s+");
+            // Layout: QSO: freq mode date time mycall <rst_sent> <serial_sent> dxcall ...
+            // mycall is token[5], rst_sent token[6], serial_sent token[7]
+            assertEquals(String.format("%03d", i + 1), tok[7],
+                "QSO " + (i+1) + " serial_sent should be " + String.format("%03d", i+1)
+                + " but row is:\n" + l);
+        }
+
+        // Chronological order verified by call ordering too.
+        assertTrue(qsoLines.get(0).contains("DL5XX"));
+        assertTrue(qsoLines.get(11).contains("K1AR"));
+    }
+}

--- a/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterCqWwTest.java
+++ b/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterCqWwTest.java
@@ -1,0 +1,142 @@
+package com.jlog.export;
+
+import com.jlog.db.ContestQsoDao;
+import com.jlog.db.DatabaseManager;
+import com.jlog.model.QsoRecord;
+import com.jlog.plugin.ContestPlugin;
+import com.jlog.plugin.PluginLoader;
+import com.jlog.util.AppConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Realistic Cabrillo export check for CQ WorldWide DX SSB. Both sides
+ * exchange RS + CQ Zone (e.g. "59 05"). Multipliers are per-band zone +
+ * per-band DXCC country. Asymmetric scoring: same-country = 0 pts,
+ * same-continent = 1 pt, different-continent = 3 pts (US ↔ EU/JA).
+ *
+ * Plugin spec:
+ *   cabrilloSent: ["rst_sent", "zone_sent"]   — zone_sent = field2 (operator's zone)
+ *   cabrilloRcvd: ["rst_rcvd", "cq_zone"]     — cq_zone = field1 (their zone)
+ *
+ * Slot mapping: cq_zone → field1, zone_sent → field2.
+ *
+ * Expected QSO line shape (sponsor: CQ):
+ *   QSO: <freq> <mode> <date> <time> <mycall> 59 05 <dxcall> 59 <theirZone>
+ */
+class CabrilloExporterCqWwTest {
+
+    @BeforeAll
+    static void initDb(@TempDir Path tmpHome) throws Exception {
+        System.setProperty("user.home", tmpHome.toString());
+        AppConfig.getInstance().load();
+        DatabaseManager.getInstance().initAll();
+        PluginLoader.getInstance().init();
+    }
+
+    @BeforeEach
+    void wipeContestQso() throws Exception {
+        try (Statement st = DatabaseManager.getInstance().getContestConnection().createStatement()) {
+            st.executeUpdate("DELETE FROM contest_qso");
+        }
+    }
+
+    @Test
+    void exportsTwelveQsoCqWwSsbLogToWellFormedCabrillo(@TempDir Path dir) throws Exception {
+        ContestPlugin plugin = PluginLoader.getInstance().getById("CQ_WW_SSB");
+        assertNotNull(plugin, "CQ_WW_SSB plugin must be loaded");
+
+        AppConfig cfg = AppConfig.getInstance();
+        cfg.setStationCallsign("WM3J");
+        DatabaseManager.getInstance().setConfig("station.grid", "FM19");
+        DatabaseManager.getInstance().setConfig("cab.operator", "SINGLE-OP");
+        DatabaseManager.getInstance().setConfig("cab.band",     "ALL");
+
+        // 12 QSOs spanning bands + zones + continents.
+        // dxCall  band   freq    zoneR  zoneSent  pts  min-offset
+        Object[][] data = {
+            {"DL5XX",  "20m", "14245", "14", "05",  3,    0},   // EU
+            {"G3ABC",  "20m", "14245", "14", "05",  3,    3},   // EU
+            {"OH2BH",  "20m", "14245", "15", "05",  3,    8},   // EU (zone 15)
+            {"JA1ZZ",  "15m", "21245", "25", "05",  3,  120},   // JA
+            {"VK3XY",  "15m", "21245", "30", "05",  3,  140},   // OC
+            {"BV2A",   "15m", "21245", "24", "05",  3,  155},   // Taiwan
+            {"PY2BB",  "10m", "28425", "11", "05",  3,  280},   // SA
+            {"LU5DX",  "10m", "28425", "13", "05",  3,  300},   // SA
+            {"K1AR",   "20m", "14245", "05", "05",  0,  420},   // US-US: 0 pts
+            {"VE3CC",  "20m", "14245", "04", "05",  2,  450},   // NA (Canada)
+            {"ZS6XX",  "40m", "7245",  "38", "05",  3,  720},   // AF
+            {"S52BT",  "40m", "7245",  "15", "05",  3,  750},   // EU (Slovenia)
+        };
+
+        LocalDateTime base = LocalDateTime.of(2026, 10, 24, 0, 0);   // CQ WW SSB last full Oct weekend
+        for (Object[] row : data) {
+            QsoRecord q = new QsoRecord();
+            q.setContestId(plugin.getContestId());
+            q.setCallsign((String) row[0]);
+            q.setBand((String) row[1]);
+            q.setFrequency((String) row[2]);
+            q.setMode("SSB");
+            q.setContestField1((String) row[3]);   // cq_zone (theirs)
+            q.setContestField2((String) row[4]);   // zone_sent (ours)
+            q.setRstSent("59");
+            q.setRstReceived("59");
+            q.setDateTimeUtc(base.plusMinutes((Integer) row[6]));
+            q.setPoints((Integer) row[5]);
+            ContestQsoDao.getInstance().insert(q);
+        }
+        assertEquals(12, ContestQsoDao.getInstance().fetchByContest("CQ_WW_SSB").size());
+
+        Path out = dir.resolve("WM3J-cq-ww-ssb.cbr");
+        CabrilloExporter.export(plugin, out);
+
+        String cabrillo = Files.readString(out);
+        System.out.println("\n=== Generated Cabrillo (" + out.getFileName() + ") ===");
+        System.out.println(cabrillo);
+        System.out.println("=== end ===\n");
+
+        List<String> lines = cabrillo.lines().toList();
+        assertEquals("START-OF-LOG: 3.0", lines.get(0).trim());
+        assertTrue(cabrillo.contains("CONTEST: CQ-WW-SSB"),
+            "header must declare CONTEST: CQ-WW-SSB");
+        assertTrue(cabrillo.contains("CALLSIGN: WM3J"));
+        assertTrue(cabrillo.contains("END-OF-LOG:"));
+
+        List<String> qsoLines = lines.stream().filter(l -> l.startsWith("QSO:")).toList();
+        assertEquals(12, qsoLines.size(), "every inserted QSO must produce a QSO: line");
+
+        // Spot-check first QSO: WM3J 59 05 DL5XX 59 14.
+        String first = qsoLines.get(0);
+        assertTrue(first.contains("WM3J"));
+        assertTrue(first.contains("DL5XX"));
+        assertTrue(first.matches(".*WM3J\\s+59\\s+05\\s+.*"),
+            "first QSO sent half must be '59 05' (RST + our zone): " + first);
+        assertTrue(first.matches(".*DL5XX\\s+59\\s+14\\b.*"),
+            "first QSO rcvd half must be '59 14' (RST + their zone): " + first);
+
+        // No-serial assertion: CQ WW has no serial number in exchange.
+        for (String l : qsoLines) {
+            // After mycall should come "59 <zone>", not "<serial> 59 ..."
+            assertTrue(l.matches(".*WM3J\\s+59\\s+\\d{1,2}\\s+.*"),
+                "QSO line must show '59 <zone>' after mycall, no serial: " + l);
+        }
+
+        // Chronological order.
+        assertTrue(qsoLines.get(0).contains("DL5XX"),
+            "first QSO line should be first-inserted DL5XX: " + qsoLines.get(0));
+        assertTrue(qsoLines.get(11).contains("S52BT"),
+            "last QSO line should be last-inserted S52BT: " + qsoLines.get(11));
+    }
+}

--- a/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterFieldDayTest.java
+++ b/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterFieldDayTest.java
@@ -1,0 +1,158 @@
+package com.jlog.export;
+
+import com.jlog.db.ContestQsoDao;
+import com.jlog.db.DatabaseManager;
+import com.jlog.model.QsoRecord;
+import com.jlog.plugin.ContestPlugin;
+import com.jlog.plugin.PluginLoader;
+import com.jlog.util.AppConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Realistic Cabrillo export check for ARRL Field Day. Both sides exchange
+ * CLASS + SECTION (e.g. "2A MDC", "1B CT", "3F STX"). No serial number.
+ *
+ * Plugin spec:
+ *   cabrilloSent: ["class_sent", "sect_sent"]   — both AppConfig constants
+ *   cabrilloRcvd: ["class_rcvd", "sect_rcvd"]   — both per-QSO
+ *
+ * Slot mapping: class_rcvd → field1, sect_rcvd → field2
+ *
+ * Expected QSO line shape (sponsor: ARRL):
+ *   QSO: <freq> <mode> <date> <time> <mycall> <classS> <sectS> <dxcall> <classR> <sectR>
+ *
+ * Mode coverage matters here — FD scores per-mode-category (CW=2pts,
+ * digital=2pts, phone=1pt) and the Cabrillo mode column must be one
+ * of CW / PH / DG. Test exercises all three so mode-token translation
+ * is visible in the dump.
+ */
+class CabrilloExporterFieldDayTest {
+
+    @BeforeAll
+    static void initDb(@TempDir Path tmpHome) throws Exception {
+        System.setProperty("user.home", tmpHome.toString());
+        AppConfig.getInstance().load();
+        DatabaseManager.getInstance().initAll();
+        PluginLoader.getInstance().init();
+    }
+
+    @BeforeEach
+    void wipeContestQso() throws Exception {
+        try (Statement st = DatabaseManager.getInstance().getContestConnection().createStatement()) {
+            st.executeUpdate("DELETE FROM contest_qso");
+        }
+    }
+
+    @Test
+    void exportsTwelveQsoFieldDayLogToWellFormedCabrillo(@TempDir Path dir) throws Exception {
+        ContestPlugin plugin = PluginLoader.getInstance().getById("ARRL_FIELD_DAY");
+        assertNotNull(plugin, "ARRL_FIELD_DAY plugin must be loaded");
+
+        AppConfig cfg = AppConfig.getInstance();
+        cfg.setStationCallsign("WM3J");
+        DatabaseManager.getInstance().setConfig("station.grid", "FM19");
+        DatabaseManager.getInstance().setConfig("cab.operator", "SINGLE-OP");
+        DatabaseManager.getInstance().setConfig("cab.band",     "ALL");
+        // Operator's Field Day class + section — constants emitted in
+        // every QSO's sent half via AppConfig.getContestConstant().
+        cfg.setContestConstant("ARRL_FIELD_DAY", "class_sent", "1D");   // 1 tx, home-station / commercial power
+        cfg.setContestConstant("ARRL_FIELD_DAY", "sect_sent",  "MDC");
+
+        // 12 QSOs across CW + SSB + FT8 (digital) on a mix of bands,
+        // working club, battery, home, and DX stations.
+        // dxCall  band  freq    mode    classR  sectR  minute-offset  pts
+        Object[][] data = {
+            {"W1AW",  "20m", "14045", "CW",  "5A", "CT",   0, 2},
+            {"K1KI",  "20m", "14045", "CW",  "2B", "EMA",  3, 2},
+            {"K8AB",  "40m", "7060",  "CW",  "3A", "OH",  85, 2},
+            {"VE3CC", "40m", "7245",  "SSB", "1D", "ONS", 130, 1},
+            {"K0FX",  "20m", "14245", "SSB", "1B", "MN",  175, 1},
+            {"N6TR",  "15m", "21045", "CW",  "1E", "OR",  240, 2},
+            {"AA6YQ", "15m", "21245", "SSB", "3F", "EB",  280, 1},
+            {"DL5XX", "10m", "28425", "SSB", "2A", "DX",  320, 1},
+            {"W6YX",  "20m", "14074", "FT8", "4F", "SCV", 480, 2},
+            {"K3LR",  "80m", "3550",  "CW",  "9A", "WPA", 720, 2},
+            {"NN3W",  "80m", "3845",  "SSB", "1D", "MDC", 780, 1},
+            {"JA1ZZ", "20m", "14074", "FT8", "1D", "DX",  900, 2},
+        };
+
+        LocalDateTime base = LocalDateTime.of(2026, 6, 27, 18, 0);    // FD Saturday 1800Z start
+        for (Object[] row : data) {
+            QsoRecord q = new QsoRecord();
+            q.setContestId(plugin.getContestId());
+            q.setCallsign((String) row[0]);
+            q.setBand((String) row[1]);
+            q.setFrequency((String) row[2]);
+            q.setMode((String) row[3]);
+            q.setContestField1((String) row[4]);   // class_rcvd
+            q.setContestField2((String) row[5]);   // sect_rcvd
+            q.setDateTimeUtc(base.plusMinutes((Integer) row[6]));
+            q.setPoints((Integer) row[7]);
+            ContestQsoDao.getInstance().insert(q);
+        }
+        assertEquals(12, ContestQsoDao.getInstance().fetchByContest("ARRL_FIELD_DAY").size());
+
+        Path out = dir.resolve("WM3J-arrl-field-day.cbr");
+        CabrilloExporter.export(plugin, out);
+
+        String cabrillo = Files.readString(out);
+        System.out.println("\n=== Generated Cabrillo (" + out.getFileName() + ") ===");
+        System.out.println(cabrillo);
+        System.out.println("=== end ===\n");
+
+        List<String> lines = cabrillo.lines().toList();
+        assertEquals("START-OF-LOG: 3.0", lines.get(0).trim());
+        assertTrue(cabrillo.contains("CONTEST: ARRL-FIELD-DAY"),
+            "header must declare CONTEST: ARRL-FIELD-DAY");
+        assertTrue(cabrillo.contains("CALLSIGN: WM3J"));
+        assertTrue(cabrillo.contains("END-OF-LOG:"));
+
+        List<String> qsoLines = lines.stream().filter(l -> l.startsWith("QSO:")).toList();
+        assertEquals(12, qsoLines.size(), "every inserted QSO must produce a QSO: line");
+
+        // Spot-check the first QSO: W1AW on 20m CW. Sent "1D MDC", rcvd "5A CT".
+        String first = qsoLines.get(0);
+        assertTrue(first.contains("WM3J"));
+        assertTrue(first.contains("W1AW"));
+        assertTrue(first.contains(" 1D ")  && first.contains(" MDC "),
+            "first QSO sent half must show our 1D MDC: " + first);
+        assertTrue(first.contains(" 5A ")  && first.contains(" CT"),
+            "first QSO rcvd half must show 5A CT: " + first);
+
+        // Mode-column translation: CW QSOs should show "CW", SSB → "PH", FT8 → "DG".
+        // The Cabrillo mode token is the 3rd whitespace-separated field after "QSO:".
+        // Counts: 5 CW, 4 SSB, 2 FT8, 1 ... actually 5 CW, 4 SSB, 2 FT8 = 11. Let me recount.
+        long cwLines = qsoLines.stream().filter(l -> l.trim().split("\\s+")[2].equals("CW")).count();
+        long phLines = qsoLines.stream().filter(l -> l.trim().split("\\s+")[2].equals("PH")).count();
+        long dgLines = qsoLines.stream().filter(l -> l.trim().split("\\s+")[2].equals("DG")).count();
+        assertEquals(5, cwLines, "expected 5 CW QSO lines (mode-col token 'CW')");
+        assertEquals(5, phLines, "expected 5 PH QSO lines (mode-col token 'PH')");
+        assertEquals(2, dgLines, "expected 2 DG QSO lines (FT8 → 'DG')");
+
+        // Chronological order — first inserted W1AW first, last inserted JA1ZZ last.
+        assertTrue(qsoLines.get(0).contains("W1AW"),
+            "first QSO line should be first-inserted W1AW: " + qsoLines.get(0));
+        assertTrue(qsoLines.get(11).contains("JA1ZZ"),
+            "last QSO line should be last-inserted JA1ZZ: " + qsoLines.get(11));
+
+        // No serial number leak. Field Day has no serial; if one bled through
+        // we'd see digits immediately after WM3J.
+        for (String l : qsoLines) {
+            assertTrue(l.matches(".*WM3J\\s+\\d[A-Z]\\s+.*"),
+                "QSO line must show class (e.g. 1D, 2A, 3F) immediately after WM3J, no serial: " + l);
+        }
+    }
+}

--- a/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterSsSsbTest.java
+++ b/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterSsSsbTest.java
@@ -1,0 +1,158 @@
+package com.jlog.export;
+
+import com.jlog.db.ContestQsoDao;
+import com.jlog.db.DatabaseManager;
+import com.jlog.model.QsoRecord;
+import com.jlog.plugin.ContestPlugin;
+import com.jlog.plugin.PluginLoader;
+import com.jlog.util.AppConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Builds a fake 12-QSO ARRL November Sweepstakes (SSB) contest log and
+ * runs {@link CabrilloExporter} against it. Prints the generated Cabrillo
+ * file to stdout for visual inspection (run with
+ * {@code mvn test -Dtest=CabrilloExporterSsSsbTest}) and asserts the
+ * structural invariants the contest sponsor checks first.
+ *
+ * SS Phone exchange:
+ *   Sent: NR PREC CALL CHK SECT — e.g. "1 B WM3J 83 MDC"
+ *   Rcvd: same — e.g. "47 A K1AR 56 CT"
+ *
+ * Per the plugin's entryFields declaration order (after the special ids
+ * callsign/serial_rcvd/serial_sent/band consume no slot):
+ *   precedence → field1, check → field2, section → field3.
+ */
+class CabrilloExporterSsSsbTest {
+
+    @BeforeAll
+    static void initDb(@TempDir Path tmpHome) throws Exception {
+        // Redirect ~/.j-log so the real DBs are untouched.
+        System.setProperty("user.home", tmpHome.toString());
+        DatabaseManager.getInstance().initAll();
+        PluginLoader.getInstance().init();
+    }
+
+    @BeforeEach
+    void wipeContestQso() throws Exception {
+        try (Statement st = DatabaseManager.getInstance().getContestConnection().createStatement()) {
+            st.executeUpdate("DELETE FROM contest_qso");
+        }
+    }
+
+    @Test
+    void exportsTwelveQsoSsSsbLogToWellFormedCabrillo(@TempDir Path dir) throws Exception {
+        ContestPlugin plugin = PluginLoader.getInstance().getById("ARRL_SS_SSB");
+        assertNotNull(plugin, "ARRL_SS_SSB plugin must be loaded");
+
+        // Station + Cabrillo categories + SS sent constants.
+        AppConfig cfg = AppConfig.getInstance();
+        cfg.setStationCallsign("WM3J");
+        // grid setter via the generic db key (no public setter on AppConfig).
+        DatabaseManager.getInstance().setConfig("station.grid", "FM19");
+        DatabaseManager.getInstance().setConfig("cab.operator", "SINGLE-OP");
+        DatabaseManager.getInstance().setConfig("cab.band",     "ALL");
+        cfg.setSsPrecedence("B");      // single-op high power
+        cfg.setSsCheck("83");          // year first licensed
+        cfg.setSsSection("MDC");       // Maryland / DC (FM19 area)
+
+        // 12 representative QSOs spanning bands, precedences, sections.
+        // Times are over the 30-hour SS window starting 2026-11-21 21:00Z.
+        Object[][] data = {
+            // dx-call, prec,  chk,  sect,  serialRcvd, serialSent, band, mode, freq,    minutes-offset
+            {"K1AR",   "A",   "56",  "CT",   "47",       "1",  "20m", "SSB", "14245",   0},
+            {"W4PA",   "B",   "84",  "TN",   "112",      "2",  "20m", "SSB", "14245",   3},
+            {"VE3EJ",  "U",   "73",  "ONS",  "8",        "3",  "20m", "SSB", "14245",   7},
+            {"N6MJ",   "U",   "92",  "SCV",  "201",      "4",  "20m", "SSB", "14245",  15},
+            {"K3ZO",   "Q",   "55",  "MDC",  "33",       "5",  "40m", "SSB",  "7245",  85},
+            {"NN3W",   "A",   "78",  "MDC",  "44",       "6",  "40m", "SSB",  "7245", 120},
+            {"WX4G",   "S",   "20",  "GA",   "12",       "7",  "40m", "SSB",  "7245", 175},
+            {"W6YX",   "M",   "62",  "SCV",  "5",        "8",  "80m", "SSB",  "3845", 360},
+            {"K0PC",   "B",   "78",  "MN",   "298",      "9",  "80m", "SSB",  "3845", 420},
+            {"K2NV",   "A",   "65",  "WNY",  "180",     "10",  "80m", "SSB",  "3845", 485},
+            {"K7RL",   "B",   "70",  "WWA",  "356",     "11",  "15m", "SSB", "21345", 1020},
+            {"VE7CC",  "U",   "60",  "BC",   "44",      "12",  "15m", "SSB", "21345", 1050},
+        };
+
+        LocalDateTime base = LocalDateTime.of(2026, 11, 21, 21, 0);
+        for (Object[] row : data) {
+            QsoRecord q = new QsoRecord();
+            q.setContestId(plugin.getContestId());
+            q.setCallsign((String) row[0]);
+            q.setContestField1((String) row[1]);   // precedence
+            q.setContestField2((String) row[2]);   // check
+            q.setContestField3((String) row[3]);   // section
+            q.setSerialReceived((String) row[4]);
+            q.setSerialSent((String) row[5]);
+            q.setBand((String) row[6]);
+            q.setMode((String) row[7]);
+            q.setFrequency((String) row[8]);
+            q.setDateTimeUtc(base.plusMinutes((Integer) row[9]));
+            q.setPoints(2);                         // SS: 2 pts per QSO
+            ContestQsoDao.getInstance().insert(q);
+        }
+        assertEquals(12, ContestQsoDao.getInstance().fetchByContest("ARRL_SS_SSB").size());
+
+        // Export.
+        Path out = dir.resolve("WM3J-arrl-ss-ssb.cbr");
+        CabrilloExporter.export(plugin, out);
+
+        // Echo to stdout for visual inspection of the generated file.
+        String cabrillo = Files.readString(out);
+        System.out.println("\n=== Generated Cabrillo (" + out.getFileName() + ") ===");
+        System.out.println(cabrillo);
+        System.out.println("=== end ===\n");
+
+        // Structural assertions — what the sponsor's robot checks first.
+        List<String> lines = cabrillo.lines().toList();
+        assertEquals("START-OF-LOG: 3.0", lines.get(0).trim(),
+            "first line must be Cabrillo 3.0 marker");
+        assertTrue(cabrillo.contains("CONTEST: ARRL-SS-SSB"),
+            "header must declare CONTEST: ARRL-SS-SSB");
+        assertTrue(cabrillo.contains("CALLSIGN: WM3J"));
+        assertTrue(cabrillo.contains("END-OF-LOG:"),
+            "log must terminate with END-OF-LOG:");
+
+        long qsoLineCount = lines.stream().filter(l -> l.startsWith("QSO:")).count();
+        assertEquals(12, qsoLineCount, "every inserted non-dupe QSO must produce a QSO: line");
+
+        // Spot-check one QSO line: K1AR is the first row. Expected sent exchange
+        // is "1 B WM3J 83 MDC" (per cabrilloSent order with station constants),
+        // received is "47 A K1AR 56 CT".
+        String k1ar = lines.stream()
+            .filter(l -> l.startsWith("QSO:") && l.contains("K1AR"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("K1AR QSO line missing"));
+        assertTrue(k1ar.contains("WM3J"),  "K1AR line must show our callsign");
+        assertTrue(k1ar.contains(" 1 ") || k1ar.contains(" 1 B "),
+            "K1AR line must contain sent serial 1");
+        assertTrue(k1ar.contains(" B "),   "K1AR line must contain sent precedence B");
+        assertTrue(k1ar.contains(" 83 "),  "K1AR line must contain sent check 83");
+        assertTrue(k1ar.contains(" MDC "), "K1AR line must contain sent section MDC");
+        assertTrue(k1ar.contains(" 47 "),  "K1AR line must contain rcvd serial 47");
+        assertTrue(k1ar.contains(" A "),   "K1AR line must contain rcvd precedence A");
+        assertTrue(k1ar.contains(" 56 "),  "K1AR line must contain rcvd check 56");
+        assertTrue(k1ar.contains(" CT"),   "K1AR line must contain rcvd section CT");
+
+        // No empty exchange fields on any QSO line — a regression indicator.
+        for (String l : lines) {
+            if (!l.startsWith("QSO:")) continue;
+            assertFalse(l.contains("  ?  ") || l.contains(" ?? "),
+                "QSO line should not contain placeholder ? tokens: " + l);
+        }
+    }
+}

--- a/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterSsSsbTest.java
+++ b/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterSsSsbTest.java
@@ -154,5 +154,22 @@ class CabrilloExporterSsSsbTest {
             assertFalse(l.contains("  ?  ") || l.contains(" ?? "),
                 "QSO line should not contain placeholder ? tokens: " + l);
         }
+
+        // QSO lines must appear in chronological order — ARRL Cabrillo spec
+        // requires it, and the underlying fetchByContest sorts DESC for the
+        // cockpit UI. Catches regression of the sort flip in CabrilloExporter.
+        // The serial-sent column is monotonic and easier to compare than the
+        // date/time fields, so use it as a stand-in for chronology.
+        List<Integer> sentSerials = lines.stream()
+            .filter(l -> l.startsWith("QSO:"))
+            .map(l -> {
+                // QSO line layout: "QSO: <freq> <mode> <date> <time> <mycall> <serial_sent> ..."
+                // Tokens 0-6 are fixed; serial_sent is token 6.
+                String[] tok = l.trim().split("\\s+");
+                return Integer.parseInt(tok[6]);
+            })
+            .toList();
+        assertEquals(List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), sentSerials,
+            "QSO lines must be in chronological (ascending serial) order");
     }
 }

--- a/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterWaeTest.java
+++ b/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterWaeTest.java
@@ -1,0 +1,177 @@
+package com.jlog.export;
+
+import com.jlog.db.ContestQsoDao;
+import com.jlog.db.ContestQtcDao;
+import com.jlog.db.DatabaseManager;
+import com.jlog.model.QsoRecord;
+import com.jlog.model.QtcRecord;
+import com.jlog.plugin.ContestPlugin;
+import com.jlog.plugin.PluginLoader;
+import com.jlog.util.AppConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Realistic Cabrillo export check for WAE-DC SSB — exercises the
+ * exporter's WAE-specific QTC subsystem ({@link CabrilloExporter}
+ * appends one {@code QTC:} line per traffic-list entry after the
+ * QSO block per WAE-DC §7).
+ *
+ * Plugin spec:
+ *   cabrilloSent: ["rst_sent", "serial_sent"]   — special, no slots
+ *   cabrilloRcvd: ["rst_rcvd", "serial_rcvd"]   — special, no slots
+ *
+ * QTC format (sponsor: DARC):
+ *   QTC: <qrg> <mode> <date> <time> <call-rx> <ser>/<size> <call-tx>
+ *        <qso-time> <qso-call> <qso-ser>
+ *
+ * Scenario: WM3J (non-EU, US side) works 8 EU stations, then sends a
+ * 5-entry QTC group to DL5XX and receives a 3-entry QTC group from
+ * G3ABC. Both QTC groups must appear after all QSO: lines and before
+ * END-OF-LOG:, with correct N/M numbering and TX/RX direction.
+ */
+class CabrilloExporterWaeTest {
+
+    @BeforeAll
+    static void initDb(@TempDir Path tmpHome) throws Exception {
+        System.setProperty("user.home", tmpHome.toString());
+        AppConfig.getInstance().load();
+        DatabaseManager.getInstance().initAll();
+        PluginLoader.getInstance().init();
+    }
+
+    @BeforeEach
+    void wipeContestTables() throws Exception {
+        try (Statement st = DatabaseManager.getInstance().getContestConnection().createStatement()) {
+            st.executeUpdate("DELETE FROM contest_qso");
+            st.executeUpdate("DELETE FROM contest_qtc");
+        }
+    }
+
+    @Test
+    void exportsWaeLogWithQtcGroupsToWellFormedCabrillo(@TempDir Path dir) throws Exception {
+        ContestPlugin plugin = PluginLoader.getInstance().getById("WAE_SSB");
+        assertNotNull(plugin, "WAE_SSB plugin must be loaded");
+
+        AppConfig cfg = AppConfig.getInstance();
+        cfg.setStationCallsign("WM3J");
+        DatabaseManager.getInstance().setConfig("station.grid", "FM19");
+        DatabaseManager.getInstance().setConfig("cab.operator", "SINGLE-OP");
+        DatabaseManager.getInstance().setConfig("cab.band",     "ALL");
+
+        // 8 QSOs working EU. WM3J sends serial 001..008.
+        String[] euCalls = {"DL5XX", "G3ABC", "F5RAB", "OH2BH", "OK1AA", "ON4UN", "S52BT", "OE1ZZ"};
+        LocalDateTime base = LocalDateTime.of(2026, 8, 8, 0, 0);   // WAE-DC SSB 2nd full Aug weekend
+        for (int i = 0; i < euCalls.length; i++) {
+            QsoRecord q = new QsoRecord();
+            q.setContestId(plugin.getContestId());
+            q.setCallsign(euCalls[i]);
+            q.setBand("20m");
+            q.setFrequency("14245");
+            q.setMode("SSB");
+            q.setRstSent("59");
+            q.setRstReceived("59");
+            q.setSerialSent(String.format("%03d", i + 1));
+            q.setSerialReceived(String.format("%03d", 100 + i));
+            q.setDateTimeUtc(base.plusMinutes(i * 5));
+            q.setPoints(1);                     // WAE: 1 pt per QSO
+            ContestQsoDao.getInstance().insert(q);
+        }
+
+        // 5-entry QTC group SENT (TX) to DL5XX at 0100Z — we replay 5 earlier QSOs.
+        LocalDateTime qtcTxAt = base.plusHours(1);
+        for (int n = 1; n <= 5; n++) {
+            QtcRecord r = new QtcRecord();
+            r.setContestId(plugin.getContestId());
+            r.setPartnerCall("DL5XX");
+            r.setDirection("TX");
+            r.setSeriesNo(n);
+            r.setSeriesSize(5);
+            r.setQtcQrg("14245");
+            r.setQtcBand("20m");
+            r.setQtcMode("SSB");
+            r.setQtcDateTimeUtc(qtcTxAt);
+            // Each QTC entry replays one earlier QSO: time + call + serial.
+            r.setQsoTime(String.format("%04d", n * 5));         // "0005", "0010", ...
+            r.setQsoCall(euCalls[n - 1]);
+            r.setQsoSerial(String.format("%03d", n));
+            ContestQtcDao.getInstance().insert(r);
+        }
+
+        // 3-entry QTC group RECEIVED (RX) from G3ABC at 0200Z.
+        LocalDateTime qtcRxAt = base.plusHours(2);
+        for (int n = 1; n <= 3; n++) {
+            QtcRecord r = new QtcRecord();
+            r.setContestId(plugin.getContestId());
+            r.setPartnerCall("G3ABC");
+            r.setDirection("RX");
+            r.setSeriesNo(n);
+            r.setSeriesSize(3);
+            r.setQtcQrg("14245");
+            r.setQtcBand("20m");
+            r.setQtcMode("SSB");
+            r.setQtcDateTimeUtc(qtcRxAt);
+            r.setQsoTime(String.format("%04d", 30 + n * 5));    // "0035", "0040", "0045"
+            r.setQsoCall("PA3" + (char) ('A' + n - 1) + "BC");  // fake EU calls G3ABC's log
+            r.setQsoSerial(String.format("%03d", 200 + n));
+            ContestQtcDao.getInstance().insert(r);
+        }
+
+        Path out = dir.resolve("WM3J-wae-ssb.cbr");
+        CabrilloExporter.export(plugin, out);
+
+        String cabrillo = Files.readString(out);
+        System.out.println("\n=== Generated Cabrillo (" + out.getFileName() + ") ===");
+        System.out.println(cabrillo);
+        System.out.println("=== end ===\n");
+
+        List<String> lines = cabrillo.lines().toList();
+        assertEquals("START-OF-LOG: 3.0", lines.get(0).trim());
+        assertTrue(cabrillo.contains("CONTEST: WAE-SSB"),
+            "header must declare CONTEST: WAE-SSB");
+        assertTrue(cabrillo.contains("END-OF-LOG:"));
+
+        List<String> qsoLines = lines.stream().filter(l -> l.startsWith("QSO:")).toList();
+        List<String> qtcLines = lines.stream().filter(l -> l.startsWith("QTC:")).toList();
+        assertEquals(8, qsoLines.size(), "all 8 QSOs must produce QSO: lines");
+        assertEquals(8, qtcLines.size(), "QTC group of 5 + group of 3 = 8 QTC: lines");
+
+        // Block ordering: every QSO: must appear before every QTC: in the file.
+        int lastQsoIdx = -1, firstQtcIdx = Integer.MAX_VALUE;
+        for (int i = 0; i < lines.size(); i++) {
+            if (lines.get(i).startsWith("QSO:")) lastQsoIdx = i;
+            if (lines.get(i).startsWith("QTC:") && i < firstQtcIdx) firstQtcIdx = i;
+        }
+        assertTrue(lastQsoIdx < firstQtcIdx,
+            "all QSO: lines must precede all QTC: lines (WAE-DC §7 ordering)");
+
+        // Spot-check first TX QTC line: "QTC: 14245 PH ... DL5XX 1/5 WM3J ..."
+        // ('PH' is the Cabrillo SSB mode token; DL5XX is the recipient,
+        // WM3J is the sender.)
+        String firstTxQtc = qtcLines.stream().filter(l -> l.contains("DL5XX")).findFirst()
+            .orElseThrow(() -> new AssertionError("no TX QTC line for DL5XX in:\n" + cabrillo));
+        assertTrue(firstTxQtc.contains(" 1/5 "),
+            "first TX QTC must show 1/5 numbering: " + firstTxQtc);
+        // recipient (DL5XX) precedes the N/M token; sender (WM3J) follows.
+        assertTrue(firstTxQtc.matches(".*DL5XX\\s+1/5\\s+WM3J\\s+.*"),
+            "TX QTC layout: recipient 1/5 sender ... : " + firstTxQtc);
+
+        // Spot-check first RX QTC line: G3ABC is sender, WM3J is recipient.
+        String firstRxQtc = qtcLines.stream().filter(l -> l.contains(" 1/3 ")).findFirst()
+            .orElseThrow(() -> new AssertionError("no RX QTC line with 1/3 in:\n" + cabrillo));
+        assertTrue(firstRxQtc.matches(".*WM3J\\s+1/3\\s+G3ABC\\s+.*"),
+            "RX QTC layout: WM3J(recipient) 1/3 G3ABC(sender) ... : " + firstRxQtc);
+    }
+}

--- a/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterWiQsoPartyTest.java
+++ b/j-log-engine/src/test/java/com/jlog/export/CabrilloExporterWiQsoPartyTest.java
@@ -1,0 +1,140 @@
+package com.jlog.export;
+
+import com.jlog.db.ContestQsoDao;
+import com.jlog.db.DatabaseManager;
+import com.jlog.model.QsoRecord;
+import com.jlog.plugin.ContestPlugin;
+import com.jlog.plugin.PluginLoader;
+import com.jlog.util.AppConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Realistic Cabrillo export check for Wisconsin QSO Party — representative
+ * of the state-QSO-party family (one of the largest plugin groups, ~50
+ * plugins).
+ *
+ * Exchange shape:
+ *   WI sends 3-letter county code (DAN, MIL, WAU, …)
+ *   Non-WI sends state / province / country
+ *
+ * Plugin spec:
+ *   cabrilloSent: ["rst_sent", "state_prov_sent"]  → field2
+ *   cabrilloRcvd: ["rst_rcvd", "state_prov_rcvd"]  → field1
+ *
+ * Slot mapping: state_prov_rcvd → field1, state_prov_sent → field2.
+ *
+ * Scenario: WM3J in PA (non-WI) works 10 WI stations across different
+ * counties spanning the high bands and CW + SSB + Digital modes.
+ */
+class CabrilloExporterWiQsoPartyTest {
+
+    @BeforeAll
+    static void initDb(@TempDir Path tmpHome) throws Exception {
+        System.setProperty("user.home", tmpHome.toString());
+        AppConfig.getInstance().load();
+        DatabaseManager.getInstance().initAll();
+        PluginLoader.getInstance().init();
+    }
+
+    @BeforeEach
+    void wipeContestQso() throws Exception {
+        try (Statement st = DatabaseManager.getInstance().getContestConnection().createStatement()) {
+            st.executeUpdate("DELETE FROM contest_qso");
+        }
+    }
+
+    @Test
+    void exportsWisconsinQsoPartyLogToWellFormedCabrillo(@TempDir Path dir) throws Exception {
+        ContestPlugin plugin = PluginLoader.getInstance().getById("WI_QSO_PARTY");
+        assertNotNull(plugin, "WI_QSO_PARTY plugin must be loaded");
+
+        AppConfig cfg = AppConfig.getInstance();
+        cfg.setStationCallsign("WM3J");
+        DatabaseManager.getInstance().setConfig("station.grid", "FM19");
+        DatabaseManager.getInstance().setConfig("cab.operator", "SINGLE-OP");
+        DatabaseManager.getInstance().setConfig("cab.band",     "ALL");
+
+        // 10 QSOs to WI stations across 10 different WI counties.
+        // dxCall   band   freq    mode    countyRcvd   pts  minute
+        Object[][] data = {
+            {"W9RE",  "20m", "14245", "SSB",  "DAN",  2,    0},   // Dane
+            {"K9NW",  "20m", "14245", "SSB",  "MIL",  2,    3},   // Milwaukee
+            {"K9OM",  "20m", "14045", "CW",   "WAU",  3,   30},   // Waukesha (CW = 3 pts)
+            {"WB9Z",  "20m", "14045", "CW",   "WIN",  3,   45},   // Winnebago
+            {"N9NB",  "40m", "7245", "SSB",   "BRO",  2,  120},   // Brown
+            {"AA9A",  "40m", "7045", "CW",    "ROC",  3,  140},   // Rock
+            {"K0PC",  "80m", "3845", "SSB",   "DAN",  2,  400},   // Dane (different op, same county — re-mult? No, mult is per county once)
+            {"N9SE",  "15m", "21080", "RTTY", "EAU",  3,  520},   // Eau Claire (RTTY = 3 pts)
+            {"K9YY",  "15m", "21245", "SSB",  "LAC",  2,  540},   // La Crosse
+            {"W9XT",  "10m", "28080", "RTTY", "OUT",  3,  690},   // Outagamie
+        };
+
+        LocalDateTime base = LocalDateTime.of(2026, 3, 14, 18, 0);   // WI QSO Party Sat 1800Z
+        for (Object[] row : data) {
+            QsoRecord q = new QsoRecord();
+            q.setContestId(plugin.getContestId());
+            q.setCallsign((String) row[0]);
+            q.setBand((String) row[1]);
+            q.setFrequency((String) row[2]);
+            q.setMode((String) row[3]);
+            q.setRstSent("59");
+            q.setRstReceived("59");
+            q.setContestField1((String) row[4]);   // state_prov_rcvd (WI county)
+            q.setContestField2("PA");               // state_prov_sent (operator's state)
+            q.setDateTimeUtc(base.plusMinutes((Integer) row[6]));
+            q.setPoints((Integer) row[5]);
+            ContestQsoDao.getInstance().insert(q);
+        }
+        assertEquals(10, ContestQsoDao.getInstance().fetchByContest("WI_QSO_PARTY").size());
+
+        Path out = dir.resolve("WM3J-wi-qso-party.cbr");
+        CabrilloExporter.export(plugin, out);
+
+        String cabrillo = Files.readString(out);
+        System.out.println("\n=== Generated Cabrillo (" + out.getFileName() + ") ===");
+        System.out.println(cabrillo);
+        System.out.println("=== end ===\n");
+
+        List<String> lines = cabrillo.lines().toList();
+        assertEquals("START-OF-LOG: 3.0", lines.get(0).trim());
+        assertTrue(cabrillo.contains("CONTEST: WI-QSO-PARTY"),
+            "header must declare CONTEST: WI-QSO-PARTY");
+        assertTrue(cabrillo.contains("CALLSIGN: WM3J"));
+        assertTrue(cabrillo.contains("END-OF-LOG:"));
+
+        List<String> qsoLines = lines.stream().filter(l -> l.startsWith("QSO:")).toList();
+        assertEquals(10, qsoLines.size());
+
+        // Spot-check first: WM3J 59 PA W9RE 59 DAN
+        String first = qsoLines.get(0);
+        assertTrue(first.matches(".*WM3J\\s+59\\s+PA\\s+.*"),
+            "first sent half '59 PA': " + first);
+        assertTrue(first.matches(".*W9RE\\s+59\\s+DAN\\b.*"),
+            "first rcvd half '59 DAN': " + first);
+
+        // Mode column translation: CW → CW, SSB → PH, RTTY → RY.
+        long cw = qsoLines.stream().filter(l -> l.trim().split("\\s+")[2].equals("CW")).count();
+        long ph = qsoLines.stream().filter(l -> l.trim().split("\\s+")[2].equals("PH")).count();
+        long ry = qsoLines.stream().filter(l -> l.trim().split("\\s+")[2].equals("RY")).count();
+        assertEquals(3, cw, "expected 3 CW QSO lines");
+        assertEquals(5, ph, "expected 5 PH (SSB) QSO lines");
+        assertEquals(2, ry, "expected 2 RY (RTTY) QSO lines");
+
+        // Chronological.
+        assertTrue(qsoLines.get(0).contains("W9RE"));
+        assertTrue(qsoLines.get(9).contains("W9XT"));
+    }
+}


### PR DESCRIPTION
## Summary
- New end-to-end test builds a fake 12-QSO ARRL November Sweepstakes (SSB) contest DB and runs `CabrilloExporter` against it, asserting structural invariants (header envelope, one `QSO:` per non-dupe record, SS-specific double-call exchange format, plugin-declared field order).
- Test caught a real bug on first run: `ContestQsoDao.fetchByContest` sorts `datetime_utc DESC` for the cockpit UI ("newest at top"), and the exporter inherited that order — so the generated Cabrillo file was reverse-chronological, which sponsors' robots may flag as malformed.
- Fix re-sorts the fetched list ascending in the exporter (one-line `stream().sorted(...).toList()` with `nullsLast` so a corrupt row missing a timestamp trails instead of throwing). DAO contract unchanged.
- Test strengthened to assert QSO lines come out in serial order 1..12, which would have caught the original DESC sort.

## Commits
- `369a3dc` — adds the SS Phone Cabrillo export test (regression pin for the discovery)
- `1f59d2c` — the fix + the chronological-order assertion

## Test plan
- [x] `mvn test -Dtest=CabrilloExporterSsSsbTest` in `j-log-engine/` passes; stdout shows ascending serial 1→12.
- [x] `mvn test -Dtest='Adif*,Cabrillo*'` — all 10 export tests pass.
- [ ] Eyeball the printed Cabrillo block in the test output and confirm it matches what the ARRL robot expects for SS SSB.
- [ ] Manual: from j-log Contest mode → Export Cabrillo on a real SS log, confirm the QSO lines are in chronological order.

## Out of scope
- `CATEGORY-MODE: MIXED` defaults regardless of actual log content; for an all-SSB log it should be `PHONE`. Noted while testing but not addressed here — it's an AppConfig/dialog issue, not an exporter bug. Operators can override pre-export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)