### PR TITLE
j-log-engine: contest ADIF export — chronological + RST defaults + STX/SRX_STRING

### DIFF
--- a/j-log-engine/src/main/java/com/jlog/export/AdifExporter.java
+++ b/j-log-engine/src/main/java/com/jlog/export/AdifExporter.java
@@ -3,6 +3,8 @@ package com.jlog.export;
 import com.jlog.db.ContestQsoDao;
 import com.jlog.db.QsoDao;
 import com.jlog.model.QsoRecord;
+import com.jlog.plugin.ContestPlugin;
+import com.jlog.plugin.PluginLoader;
 import com.jlog.util.AppConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,6 +80,32 @@ public class AdifExporter {
         String stationCall = cfg.getStationCallsign();
         String stationGrid = cfg.getGridSquare();
 
+        // ContestQsoDao + QsoDao sort datetime_utc DESC for the cockpit UI
+        // ("newest at top"). Receiving loggers (LoTW, master log import)
+        // expect ascending chronological. Re-sort here; nulls trail.
+        qsos = qsos.stream()
+            .sorted(Comparator.comparing(
+                QsoRecord::getDateTimeUtc,
+                Comparator.nullsLast(Comparator.naturalOrder())))
+            .toList();
+
+        // For contest exports, look up the plugin once so we can emit
+        // STX_STRING / SRX_STRING using the plugin's declared cabrilloSent /
+        // cabrilloRcvd field order. Same exchange string the Cabrillo
+        // exporter produces — gives downstream loggers human-readable
+        // context for the QSO even when they don't know the contest's
+        // semantic field map. Only meaningful when ALL QSOs are in one
+        // contest (typical — exportContestAdif filters by contestId).
+        ContestPlugin contestPlugin = null;
+        if (contest && !qsos.isEmpty()) {
+            String firstContestId = qsos.get(0).getContestId();
+            boolean uniform = firstContestId != null
+                && qsos.stream().allMatch(q -> firstContestId.equals(q.getContestId()));
+            if (uniform) {
+                contestPlugin = PluginLoader.getInstance().getById(firstContestId);
+            }
+        }
+
         // Lock UTF-8 explicitly — the no-arg FileWriter uses the JVM default
         // charset, which is Cp1252 on pre-JDK-18 Windows JREs and could drift
         // if file.encoding isn't set. AdifImporter accepts UTF-8 or cp1252;
@@ -101,8 +129,19 @@ public class AdifExporter {
                 adifField(pw, "BAND",      normalizeBand(q.getBand()));
                 adifField(pw, "MODE",      normalizeMode(q.getMode()));
                 adifField(pw, "FREQ",      normalizeFreqMHz(q.getFrequency()));
-                adifField(pw, "RST_SENT",  q.getRstSent());
-                adifField(pw, "RST_RCVD",  q.getRstReceived());
+                // Default RST from the mode for contest exports — many
+                // contest cockpits don't capture RST (it's not in the
+                // formal exchange for SS/CQ WW/etc.) but LoTW rejects
+                // records without RST_SENT/RST_RCVD. Normal-log exports
+                // pass through whatever the operator logged (blank OK).
+                String rstSent = q.getRstSent();
+                String rstRcvd = q.getRstReceived();
+                if (contest) {
+                    if (rstSent == null || rstSent.isBlank()) rstSent = defaultRstForMode(q.getMode());
+                    if (rstRcvd == null || rstRcvd.isBlank()) rstRcvd = defaultRstForMode(q.getMode());
+                }
+                adifField(pw, "RST_SENT",  rstSent);
+                adifField(pw, "RST_RCVD",  rstRcvd);
                 if (q.getPowerWatts() > 0) adifField(pw, "TX_PWR", String.valueOf(q.getPowerWatts()));
 
                 if (!contest) {
@@ -117,12 +156,29 @@ public class AdifExporter {
                     adifField(pw, "SIG",       q.getSig());
                     adifField(pw, "SIG_INFO",  q.getSigInfo());
                 } else {
-                    // Contest-specific: serials only. The free-form exchange
-                    // string was intentionally dropped — structured fields hold
-                    // the data and contest sponsors take Cabrillo, not ADIF.
+                    // Contest path. STX/SRX preserve numeric serials per ADIF
+                    // convention. STX_STRING/SRX_STRING carry the full
+                    // exchange in the plugin's declared transmit order
+                    // (built via the same helper Cabrillo uses, so the
+                    // two file formats agree on what was exchanged). This
+                    // makes the LoTW / master-log round-trip useful even
+                    // when the receiving logger doesn't know the contest's
+                    // semantic field map. A full per-tag mapping (ARRL_SECT,
+                    // CHECK, CQZ, GRIDSQUARE, …) is a future enhancement
+                    // requiring per-plugin adifField declarations.
                     adifField(pw, "CONTEST_ID",  q.getContestId());
                     adifField(pw, "STX",         q.getSerialSent());
                     adifField(pw, "SRX",         q.getSerialReceived());
+                    if (contestPlugin != null) {
+                        String stxString = CabrilloExporter.buildOrderedExchange(
+                            q, contestPlugin, cfg, contestPlugin.getCabrilloSent());
+                        String srxString = CabrilloExporter.buildOrderedExchange(
+                            q, contestPlugin, cfg, contestPlugin.getCabrilloRcvd());
+                        if (stxString != null && !stxString.isBlank())
+                            adifField(pw, "STX_STRING", stxString);
+                        if (srxString != null && !srxString.isBlank())
+                            adifField(pw, "SRX_STRING", srxString);
+                    }
                     adifField(pw, "OPERATOR",    q.getOperator());
                     if (q.getNotes() != null) adifField(pw, "COMMENT", q.getNotes());
                 }
@@ -215,6 +271,22 @@ public class AdifExporter {
     private static void adifField(PrintWriter pw, String tag, String value) {
         if (value == null || value.isBlank()) return;
         pw.print("<" + tag + ":" + value.length() + ">" + value + " ");
+    }
+
+    /** Conventional default RST by mode for contest exports where the
+     *  operator didn't capture RST (common — SS/CQ WW/etc. don't include
+     *  RST in the formal exchange). Phone modes get "59", CW/digital get
+     *  "599". Keeps LoTW happy without forcing operators to fill in
+     *  fields that aren't part of the contest exchange. */
+    private static String defaultRstForMode(String mode) {
+        if (mode == null) return "59";
+        String m = mode.toUpperCase();
+        if (m.contains("SSB") || m.equals("USB") || m.equals("LSB")
+                || m.equals("AM") || m.equals("FM") || m.equals("PH")
+                || m.equals("PHONE")) {
+            return "59";
+        }
+        return "599";   // CW, RTTY, FT8, PSK31, OLIVIA, MFSK, JT*, etc.
     }
 
     private static String csv(String s) {

--- a/j-log-engine/src/main/java/com/jlog/export/CabrilloExporter.java
+++ b/j-log-engine/src/main/java/com/jlog/export/CabrilloExporter.java
@@ -173,8 +173,10 @@ public class CabrilloExporter {
     }
 
     /** Build an exchange string from an explicit ordered list of field-id
-     *  tokens (declared sponsor transmit order). */
-    private static String buildOrderedExchange(QsoRecord q, ContestPlugin plugin,
+     *  tokens (declared sponsor transmit order). Package-private so
+     *  {@link AdifExporter} can reuse the same logic when emitting
+     *  STX_STRING / SRX_STRING for contest QSOs. */
+    static String buildOrderedExchange(QsoRecord q, ContestPlugin plugin,
                                                 AppConfig cfg, List<String> tokens) {
         if (tokens == null || tokens.isEmpty()) return "";
         StringBuilder sb = new StringBuilder();

--- a/j-log-engine/src/test/java/com/jlog/export/AdifContestExportSsSsbTest.java
+++ b/j-log-engine/src/test/java/com/jlog/export/AdifContestExportSsSsbTest.java
@@ -1,0 +1,160 @@
+package com.jlog.export;
+
+import com.jlog.db.ContestQsoDao;
+import com.jlog.db.DatabaseManager;
+import com.jlog.model.QsoRecord;
+import com.jlog.plugin.ContestPlugin;
+import com.jlog.plugin.PluginLoader;
+import com.jlog.util.AppConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for the contest-side ADIF export path
+ * ({@code AdifExporter.exportContestAdif}). Prints the file for human
+ * inspection AND asserts the three fixes shipped on the
+ * fix/contest-adif-export-medium branch:
+ *
+ *   1. QSO records appear in chronological order (was reverse — DAO's
+ *      UI sort leaked through, same root cause as the Cabrillo fix in
+ *      1f59d2c).
+ *   2. RST_SENT / RST_RCVD default by mode when not captured by the
+ *      contest cockpit ("59" for phone modes, "599" for CW + digital).
+ *      LoTW rejects records missing RST.
+ *   3. STX_STRING / SRX_STRING carry the full Cabrillo-style exchange
+ *      strings so downstream loggers see the exchange context even
+ *      without a per-plugin semantic ADIF tag map.
+ *
+ * Reuses the same 12-QSO ARRL November Sweepstakes (SSB) scenario from
+ * CabrilloExporterSsSsbTest so Cabrillo and ADIF can be compared
+ * side-by-side.
+ */
+class AdifContestExportSsSsbTest {
+
+    @BeforeAll
+    static void initDb(@TempDir Path tmpHome) throws Exception {
+        System.setProperty("user.home", tmpHome.toString());
+        AppConfig.getInstance().load();
+        DatabaseManager.getInstance().initAll();
+        PluginLoader.getInstance().init();
+    }
+
+    @BeforeEach
+    void wipeContestQso() throws Exception {
+        try (Statement st = DatabaseManager.getInstance().getContestConnection().createStatement()) {
+            st.executeUpdate("DELETE FROM contest_qso");
+        }
+    }
+
+    @Test
+    void dumpsArrlSsSsbContestAdifForHumanInspection(@TempDir Path dir) throws Exception {
+        ContestPlugin plugin = PluginLoader.getInstance().getById("ARRL_SS_SSB");
+
+        AppConfig cfg = AppConfig.getInstance();
+        cfg.setStationCallsign("WM3J");
+        DatabaseManager.getInstance().setConfig("station.grid", "FM19");
+        cfg.setSsPrecedence("B");
+        cfg.setSsCheck("83");
+        cfg.setSsSection("MDC");
+
+        // Same 12-QSO SS Phone scenario as CabrilloExporterSsSsbTest.
+        // Slot mapping: precedence=field1, check=field2, section=field3.
+        Object[][] data = {
+            {"K1AR",   "A",  "56", "CT",   "47",  "1", "20m", "SSB", "14245",   0},
+            {"W4PA",   "B",  "84", "TN",  "112",  "2", "20m", "SSB", "14245",   3},
+            {"VE3EJ",  "U",  "73", "ONS",   "8",  "3", "20m", "SSB", "14245",   7},
+            {"N6MJ",   "U",  "92", "SCV", "201",  "4", "20m", "SSB", "14245",  15},
+            {"K3ZO",   "Q",  "55", "MDC",  "33",  "5", "40m", "SSB",  "7245",  85},
+            {"NN3W",   "A",  "78", "MDC",  "44",  "6", "40m", "SSB",  "7245", 120},
+            {"WX4G",   "S",  "20", "GA",   "12",  "7", "40m", "SSB",  "7245", 175},
+            {"W6YX",   "M",  "62", "SCV",   "5",  "8", "80m", "SSB",  "3845", 360},
+            {"K0PC",   "B",  "78", "MN",  "298",  "9", "80m", "SSB",  "3845", 420},
+            {"K2NV",   "A",  "65", "WNY", "180", "10", "80m", "SSB",  "3845", 485},
+            {"K7RL",   "B",  "70", "WWA", "356", "11", "15m", "SSB", "21345",1020},
+            {"VE7CC",  "U",  "60", "BC",   "44", "12", "15m", "SSB", "21345",1050},
+        };
+        LocalDateTime base = LocalDateTime.of(2026, 11, 21, 21, 0);
+        for (Object[] row : data) {
+            QsoRecord q = new QsoRecord();
+            q.setContestId(plugin.getContestId());
+            q.setCallsign((String) row[0]);
+            q.setContestField1((String) row[1]);   // precedence
+            q.setContestField2((String) row[2]);   // check
+            q.setContestField3((String) row[3]);   // section
+            q.setSerialReceived((String) row[4]);
+            q.setSerialSent((String) row[5]);
+            q.setBand((String) row[6]);
+            q.setMode((String) row[7]);
+            q.setFrequency((String) row[8]);
+            q.setDateTimeUtc(base.plusMinutes((Integer) row[9]));
+            q.setPoints(2);
+            ContestQsoDao.getInstance().insert(q);
+        }
+
+        Path out = dir.resolve("WM3J-arrl-ss-ssb.adi");
+        AdifExporter.exportContestAdif(plugin.getContestId(), out);
+
+        String adif = Files.readString(out);
+        System.out.println("\n=== Generated contest ADIF (" + out.getFileName() + ") ===");
+        System.out.println(adif);
+        System.out.println("=== end ===\n");
+
+        // --- Fix #1: chronological order ---
+        // Extract callsign from each record in file order.
+        // Records are "<CALL:N>XXXXX ..." lines separated by <EOR>.
+        Pattern callPat = Pattern.compile("<CALL:(\\d+)>([^ ]+)");
+        Matcher m = callPat.matcher(adif);
+        java.util.List<String> callOrder = new java.util.ArrayList<>();
+        while (m.find()) callOrder.add(m.group(2));
+        assertEquals(12, callOrder.size(), "all 12 QSO records must be present");
+        assertEquals("K1AR",  callOrder.get(0),  "first record must be the first-inserted K1AR (chronological)");
+        assertEquals("VE7CC", callOrder.get(11), "last record must be the last-inserted VE7CC");
+
+        // --- Fix #2: RST defaulting ---
+        // Test data left RST unset; mode is SSB so contest export should
+        // default both to "59". Should appear in every record.
+        long rstSentCount = countMatches(adif, "<RST_SENT:2>59 ");
+        long rstRcvdCount = countMatches(adif, "<RST_RCVD:2>59 ");
+        assertEquals(12, rstSentCount, "RST_SENT:59 expected on every SSB record (default for blank)");
+        assertEquals(12, rstRcvdCount, "RST_RCVD:59 expected on every SSB record (default for blank)");
+
+        // --- Fix #3: STX_STRING / SRX_STRING ---
+        // First QSO is K1AR. Sent exchange per the SS plugin
+        // cabrilloSent = [serial_sent, prec_sent, mycall, check_sent, sect_sent]
+        // → "1 B WM3J 83 MDC". Received cabrilloRcvd
+        // = [serial_rcvd, precedence, callsign, check, section]
+        // → "47 A K1AR 56 CT".
+        String k1arRecord = extractRecordContaining(adif, "K1AR");
+        assertTrue(k1arRecord.contains("<STX_STRING:15>1 B WM3J 83 MDC"),
+            "K1AR record must include STX_STRING for sent exchange:\n" + k1arRecord);
+        assertTrue(k1arRecord.contains("<SRX_STRING:15>47 A K1AR 56 CT"),
+            "K1AR record must include SRX_STRING for received exchange:\n" + k1arRecord);
+    }
+
+    private static long countMatches(String haystack, String needle) {
+        long count = 0;
+        int idx = 0;
+        while ((idx = haystack.indexOf(needle, idx)) != -1) { count++; idx += needle.length(); }
+        return count;
+    }
+
+    private static String extractRecordContaining(String adif, String callsign) {
+        for (String chunk : adif.split("(?i)<EOR>")) {
+            if (chunk.contains(callsign)) return chunk.trim();
+        }
+        throw new AssertionError("no record found containing " + callsign + " in:\n" + adif);
+    }
+}


### PR DESCRIPTION
## Summary

Audit of `AdifExporter.exportContestAdif` against the same 12-QSO ARRL November Sweepstakes (SSB) scenario the Cabrillo deep-dive tests use surfaced three real issues for the operator's LoTW / eQSL / master-log workflow:

### 1. Reverse-chronological QSO order
Same root cause as the Cabrillo fix in `1f59d2c` — `ContestQsoDao.fetchByContest` sorts `datetime_utc DESC` for the cockpit UI; the ADIF exporter inherited that order. Fix mirrors the Cabrillo pattern (sort ascending before iterating, nulls last).

### 2. RST_SENT / RST_RCVD missing on every record
Many contest exchanges (SS, CQ WW, CQ WPX, June VHF, …) don't include RST as a formal field, so the cockpit doesn't capture it and the DB stores blank. **LoTW rejects records without RST.** Fix: default per-mode in the contest branch only — `"59"` for phone modes, `"599"` for CW + digital. Normal-log exports pass through whatever the operator logged.

### 3. All structured exchange data thrown away
The contest branch wrote `CONTEST_ID + STX + SRX` and nothing else; precedence, check, section, county, grid, zone, class, etc. all vanished. Master loggers had no way to reconstruct the exchange and the operator lost award-credit data (SS section, WAZ zone, VUCC grid, …).

Fix: emit `STX_STRING` + `SRX_STRING` built via the same `CabrilloExporter.buildOrderedExchange` helper (made package-private for reuse), so ADIF carries the same plugin-declared exchange string Cabrillo emits. Receiving loggers see human-readable exchange context even without a per-plugin semantic ADIF tag map.

## Out of scope (future enhancement)

A full per-tag mapping (`ARRL_SECT`, `CHECK`, `CQZ`, `GRIDSQUARE`, `STATE`, `CNTY`, …) would let receiving loggers parse the exchange into structured columns for award tracking. That needs an `adifField` declaration per entry field on each affected plugin (~30+ plugins). Deferred for a separate initiative; this PR ships the medium-scope cut that solves the loud bugs (#1 order, #2 LoTW-blocking blank RST) and the meaningful workflow gap (#3 exchange data via STX_STRING/SRX_STRING).

## Test plan

- [x] New `AdifContestExportSsSsbTest` dumps the 12-QSO SS Phone log to a contest ADIF file for human inspection and asserts all three fixes (K1AR first / VE7CC last, RST_SENT:2>59 on every record, STX_STRING "1 B WM3J 83 MDC" + SRX_STRING "47 A K1AR 56 CT" on the first record).
- [x] Full j-log-engine suite — 141/141 pass.
- [ ] Manual: export an SS Phone contest log from j-log Contest mode → ADIF, then upload to LoTW or import into a master logger and confirm RST + exchange tokens appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)