### PR TITLE
j-hub: cd in start.sh + start.bat (siblings missed by 238dc20)

### DIFF
--- a/j-hub/start.bat
+++ b/j-hub/start.bat
@@ -11,5 +11,6 @@ if not defined JAR (
   echo Error: j-hub jar not found in "%SCRIPT_DIR%target" - build it:  mvn -DskipTests -f "%SCRIPT_DIR%pom.xml" package
   exit /b 1
 )
+cd /d "%SCRIPT_DIR%"
 java -Dfile.encoding=UTF-8 -jar "%JAR%" %*
 endlocal

--- a/j-hub/start.sh
+++ b/j-hub/start.sh
@@ -12,6 +12,7 @@ if [ -z "$JAR" ]; then
   exit 1
 fi
 
+cd "$SCRIPT_DIR"
 exec java \
     -Dfile.encoding=UTF-8 \
     -jar "$JAR" \


### PR DESCRIPTION
## Summary

Commit `238dc20` added `cd "$SCRIPT_DIR"` to every `j-*.{sh,bat}` launcher to fix the rogue-`logs/` problem and keep per-module config files where the module dir is. Two siblings in `j-hub/` were missed — `start.sh` and `start.bat` — because my audit pattern matched `j-*.sh`/`j-*.bat` and skipped over `start.*`.

## Symptom this caused

The other modules' `ensureJHubRunning()` spawns `bash ${root}/j-hub/start.sh` via `ProcessBuilder`, which inherits the parent's cwd. After `238dc20`, j-log/j-sat/j-bridge/j-map all correctly have `cwd=<module>/` — but `start.sh` then `exec java` without `cd`-ing first, so the child j-hub process inherited the LAUNCHING module's cwd, not its own. j-hub then wrote `j-hub.json` to the wrong directory.

WM3J's case today: j-log auto-launched j-hub, j-hub wrote config to `j-log/j-hub.json`, next direct launch of j-hub read the (blank) `j-hub/j-hub.json` and the DX cluster server/login were "lost." Took 10 minutes to track down the 9 stray `j-hub.json` files across his disk.

## Fix

One line per file, same shape as `238dc20`:
- `j-hub/start.sh`: `cd "$SCRIPT_DIR"` before `exec java`
- `j-hub/start.bat`: `cd /d "%SCRIPT_DIR%"` before `java -jar`

## Test plan
- [x] `grep cd` confirms both files have the fix
- [x] Smoke test: `( cd /tmp && /home/mike/ARS_Suite/j-hub/start.sh )` — no rogue `/tmp/logs/` created (was created before the fix)
- [ ] Manual: launch j-log on a fresh machine, confirm UI-saved cluster settings persist across j-hub restart (the bug WM3J hit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)