### PR TITLE
j-log: review + edit-and-approve dialog for ADIF import rejections

### DIFF
--- a/j-log-engine/src/main/java/com/jlog/export/AdifImporter.java
+++ b/j-log-engine/src/main/java/com/jlog/export/AdifImporter.java
@@ -41,11 +41,45 @@ public class AdifImporter {
         public int skipped;
         public int overwritten;
         public int failed;
-        public List<String> failures = new ArrayList<>();
+        /** Per-record rejections — operator can review/edit/approve via
+         *  the j-log Rejected QSOs dialog. Replaces the prior
+         *  {@code List<String>} of bare reason strings so the UI has the
+         *  parsed fields available to populate an edit form. */
+        public List<RejectedRecord> failures = new ArrayList<>();
 
         @Override public String toString() {
             return String.format("imported=%d overwritten=%d skipped=%d failed=%d",
                 imported, overwritten, skipped, failed);
+        }
+    }
+
+    /** One rejected ADIF record carried back to the UI for review. */
+    public static class RejectedRecord {
+        /** 1-based record number within the import — useful when the
+         *  operator opens the source file to track down a row. */
+        public final int recordNumber;
+        /** Why we didn't insert it (e.g. "Missing CALL in record",
+         *  "UNIQUE constraint failed: …"). */
+        public final String reason;
+        /** Raw ADIF tag → value map as parsed. Empty if parsing yielded
+         *  nothing. Allows the UI to pre-populate an edit form even when
+         *  the record was missing required fields. */
+        public final Map<String, String> fields;
+        /** Best-effort QsoRecord built from {@link #fields}. Whatever
+         *  could be extracted is set; missing/invalid values are blank
+         *  or null. Operator fills the gap before re-saving. */
+        public final QsoRecord partial;
+
+        public RejectedRecord(int recordNumber, String reason,
+                              Map<String, String> fields, QsoRecord partial) {
+            this.recordNumber = recordNumber;
+            this.reason       = reason;
+            this.fields       = fields == null ? Map.of() : Map.copyOf(fields);
+            this.partial      = partial;
+        }
+
+        @Override public String toString() {
+            return "#" + recordNumber + ": " + reason;
         }
     }
 
@@ -60,7 +94,11 @@ public class AdifImporter {
         int bodyStart = indexOfIgnoreCase(content, "<EOH>");
         int cursor = bodyStart >= 0 ? bodyStart + 5 : 0;
 
-        parseRecords(content, cursor, rec -> applyRecord(rec, dupeMode, r));
+        int[] recordCounter = {0};
+        parseRecords(content, cursor, rec -> {
+            recordCounter[0]++;
+            applyRecord(rec, dupeMode, r, recordCounter[0]);
+        });
         log.info("ADIF import from {} — {}", source, r);
         return r;
     }
@@ -143,12 +181,15 @@ public class AdifImporter {
     // Record → DB
     // -----------------------------------------------------------------
 
-    private static void applyRecord(Map<String, String> fields, DupeMode dupeMode, Result r) {
+    private static void applyRecord(Map<String, String> fields, DupeMode dupeMode,
+                                    Result r, int recordNumber) {
+        QsoRecord q = null;
         try {
-            QsoRecord q = toQso(fields);
+            q = toQso(fields);
             if (q.getCallsign() == null || q.getCallsign().isBlank()) {
                 r.failed++;
-                r.failures.add("Missing CALL in record");
+                r.failures.add(new RejectedRecord(
+                    recordNumber, "Missing CALL in record", fields, q));
                 return;
             }
             String band = q.getBand() == null ? "" : q.getBand();
@@ -171,7 +212,10 @@ public class AdifImporter {
             r.imported++;
         } catch (Exception ex) {
             r.failed++;
-            r.failures.add(ex.getMessage() == null ? ex.toString() : ex.getMessage());
+            r.failures.add(new RejectedRecord(
+                recordNumber,
+                ex.getMessage() == null ? ex.toString() : ex.getMessage(),
+                fields, q));
         }
     }
 

--- a/j-log-engine/src/test/java/com/jlog/export/AdifImporterTest.java
+++ b/j-log-engine/src/test/java/com/jlog/export/AdifImporterTest.java
@@ -15,6 +15,7 @@ import java.sql.Statement;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * End-to-end check that AdifImporter's three DupeMode branches each touch
@@ -124,7 +125,18 @@ class AdifImporterTest {
         AdifImporter.Result r = AdifImporter.importAdif(adif, AdifImporter.DupeMode.SKIP);
         assertEquals(0, r.imported);
         assertEquals(1, r.failed);
-        assertEquals(List.of("Missing CALL in record"), r.failures);
+        assertEquals(1, r.failures.size());
+        AdifImporter.RejectedRecord rej = r.failures.get(0);
+        assertEquals(1, rej.recordNumber);
+        assertEquals("Missing CALL in record", rej.reason);
+        // Parsed fields preserved so the Rejected QSOs dialog can pre-populate
+        // the editor with the BAND / MODE that were present.
+        assertEquals("20m", rej.fields.get("BAND"));
+        assertEquals("CW",  rej.fields.get("MODE"));
+        // Partial QsoRecord has band/mode but blank callsign.
+        assertEquals("20m", rej.partial.getBand());
+        assertEquals("CW",  rej.partial.getMode());
+        assertTrue(rej.partial.getCallsign() == null || rej.partial.getCallsign().isBlank());
     }
 
     /**

--- a/j-log/src/main/java/com/jlog/controller/NormalLogController.java
+++ b/j-log/src/main/java/com/jlog/controller/NormalLogController.java
@@ -239,10 +239,14 @@ public class NormalLogController implements Initializable {
                 }
                 @Override protected void succeeded() {
                     var r = getValue();
-                    setStatus("ADIF import: " + r.imported + " imported, " + r.skipped + " skipped");
+                    setStatus("ADIF import: " + r.imported + " imported, "
+                        + r.skipped + " skipped, " + r.failed + " rejected");
                     loadQsos();
                     try { java.nio.file.Files.deleteIfExists(java.nio.file.Path.of(path)); }
                     catch (Exception ignored) {}
+                    if (r.failed > 0 && !r.failures.isEmpty()) {
+                        RejectedQsosDialog.show(r.failures, () -> loadQsos());
+                    }
                 }
                 @Override protected void failed() {
                     setStatus("ADIF import failed: " + getException().getMessage());
@@ -1180,6 +1184,9 @@ public class NormalLogController implements Initializable {
                 setStatus("Imported " + r.imported + ", skipped " + r.skipped
                           + ", failed " + r.failed);
                 loadQsos();
+                if (r.failed > 0 && !r.failures.isEmpty()) {
+                    RejectedQsosDialog.show(r.failures, () -> loadQsos());
+                }
             }
             @Override protected void failed() { setStatus("Import failed: " + getException().getMessage()); }
         };

--- a/j-log/src/main/java/com/jlog/controller/RejectedQsosDialog.java
+++ b/j-log/src/main/java/com/jlog/controller/RejectedQsosDialog.java
@@ -1,0 +1,235 @@
+package com.jlog.controller;
+
+import com.jlog.db.QsoDao;
+import com.jlog.export.AdifImporter;
+import com.jlog.model.QsoRecord;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.*;
+import javafx.scene.layout.*;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import javafx.util.Callback;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+/**
+ * Modal "Rejected QSO Records" review dialog.
+ * <p>
+ * Opens after an ADIF import that produced one or more rejections (e.g.
+ * missing CALL, DB constraint violation). Operator sees one row per
+ * rejection with the reason and whatever was parsed; an "Edit &amp; Approve"
+ * button per row pops a small editor pre-filled from the parsed fields,
+ * lets the operator fix what was missing, and inserts the record on Save.
+ * Closing the dialog triggers {@code onClose} so the main controller
+ * refreshes its QSO table.
+ */
+public final class RejectedQsosDialog {
+
+    private static final DateTimeFormatter DT_DISPLAY =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    private static final DateTimeFormatter DT_PARSE =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    private RejectedQsosDialog() {}
+
+    /** Open the dialog on the JavaFX thread. {@code onClose} runs after the
+     *  operator dismisses the window — typically a {@code loadQsos()} call
+     *  so any approved records show up in the main log table. */
+    public static void show(List<AdifImporter.RejectedRecord> rejected, Runnable onClose) {
+        Stage stage = new Stage();
+        stage.setTitle("Rejected QSO Records (" + rejected.size() + ")");
+        stage.initModality(Modality.NONE);   // non-modal so operator can switch tabs
+
+        ObservableList<AdifImporter.RejectedRecord> data =
+            FXCollections.observableArrayList(rejected);
+
+        TableView<AdifImporter.RejectedRecord> table = new TableView<>(data);
+        table.setPlaceholder(new Label("All rejections resolved — close this window."));
+
+        TableColumn<AdifImporter.RejectedRecord, String> colNum = new TableColumn<>("#");
+        colNum.setCellValueFactory(c -> new SimpleStringProperty(String.valueOf(c.getValue().recordNumber)));
+        colNum.setPrefWidth(50);
+        colNum.setStyle("-fx-alignment: CENTER;");
+
+        TableColumn<AdifImporter.RejectedRecord, String> colReason = new TableColumn<>("Reason");
+        colReason.setCellValueFactory(c -> new SimpleStringProperty(c.getValue().reason));
+        colReason.setPrefWidth(260);
+
+        TableColumn<AdifImporter.RejectedRecord, String> colCall = new TableColumn<>("Callsign");
+        colCall.setCellValueFactory(c -> new SimpleStringProperty(
+            c.getValue().partial != null ? safe(c.getValue().partial.getCallsign()) : ""));
+        colCall.setPrefWidth(100);
+        colCall.setStyle("-fx-alignment: CENTER;");
+
+        TableColumn<AdifImporter.RejectedRecord, String> colDate = new TableColumn<>("Date / Time");
+        colDate.setCellValueFactory(c -> new SimpleStringProperty(
+            c.getValue().partial != null && c.getValue().partial.getDateTimeUtc() != null
+                ? c.getValue().partial.getDateTimeUtc().format(DT_DISPLAY) : ""));
+        colDate.setPrefWidth(130);
+        colDate.setStyle("-fx-alignment: CENTER;");
+
+        TableColumn<AdifImporter.RejectedRecord, String> colBand = new TableColumn<>("Band");
+        colBand.setCellValueFactory(c -> new SimpleStringProperty(
+            c.getValue().partial != null ? safe(c.getValue().partial.getBand()) : ""));
+        colBand.setPrefWidth(60);
+        colBand.setStyle("-fx-alignment: CENTER;");
+
+        TableColumn<AdifImporter.RejectedRecord, String> colMode = new TableColumn<>("Mode");
+        colMode.setCellValueFactory(c -> new SimpleStringProperty(
+            c.getValue().partial != null ? safe(c.getValue().partial.getMode()) : ""));
+        colMode.setPrefWidth(70);
+        colMode.setStyle("-fx-alignment: CENTER;");
+
+        TableColumn<AdifImporter.RejectedRecord, Void> colAction = new TableColumn<>("Action");
+        colAction.setPrefWidth(200);
+        colAction.setCellFactory(actionCellFactory(stage, data));
+
+        table.getColumns().addAll(colNum, colReason, colCall, colDate, colBand, colMode, colAction);
+
+        Label header = new Label(
+            "Review records the import couldn't insert. Click Edit & Approve to fix the\n" +
+            "missing or invalid fields, or Skip to drop the record from this list.");
+        header.setWrapText(true);
+        header.setPadding(new Insets(6, 8, 6, 8));
+
+        Button btnCloseAll = new Button("Close");
+        btnCloseAll.setOnAction(e -> stage.close());
+        HBox bottom = new HBox(btnCloseAll);
+        bottom.setAlignment(Pos.CENTER_RIGHT);
+        bottom.setPadding(new Insets(8));
+
+        BorderPane root = new BorderPane();
+        root.setTop(header);
+        root.setCenter(table);
+        root.setBottom(bottom);
+
+        Scene scene = new Scene(root, 980, 460);
+        stage.setScene(scene);
+        stage.setOnHiding(e -> { if (onClose != null) onClose.run(); });
+        stage.show();
+    }
+
+    /** Builds the per-row "Edit & Approve" + "Skip" button cell. */
+    private static Callback<TableColumn<AdifImporter.RejectedRecord, Void>,
+                             TableCell<AdifImporter.RejectedRecord, Void>>
+        actionCellFactory(Stage parent, ObservableList<AdifImporter.RejectedRecord> data) {
+        return col -> new TableCell<>() {
+            private final Button edit = new Button("Edit & Approve");
+            private final Button skip = new Button("Skip");
+            private final HBox box   = new HBox(6, edit, skip);
+            {
+                box.setAlignment(Pos.CENTER);
+                edit.setOnAction(e -> {
+                    AdifImporter.RejectedRecord rej = getTableView().getItems().get(getIndex());
+                    QsoRecord seed = rej.partial != null ? rej.partial : new QsoRecord();
+                    QsoRecord edited = openEditor(parent, seed, rej.reason);
+                    if (edited == null) return;  // cancelled
+                    try {
+                        QsoDao.getInstance().insert(edited);
+                        data.remove(rej);
+                    } catch (Exception ex) {
+                        Alert a = new Alert(Alert.AlertType.ERROR,
+                            "Insert failed: " + ex.getMessage(), ButtonType.OK);
+                        a.setHeaderText("Could not insert record");
+                        a.showAndWait();
+                    }
+                });
+                skip.setOnAction(e -> {
+                    AdifImporter.RejectedRecord rej = getTableView().getItems().get(getIndex());
+                    data.remove(rej);
+                });
+            }
+            @Override protected void updateItem(Void v, boolean empty) {
+                super.updateItem(v, empty);
+                setGraphic(empty ? null : box);
+            }
+        };
+    }
+
+    /** Open a small modal editor pre-populated from {@code seed}. Returns
+     *  the edited record on Save, or null on Cancel. Callsign is required;
+     *  Save stays disabled until it has a value. */
+    private static QsoRecord openEditor(Stage parent, QsoRecord seed, String rejectionReason) {
+        Dialog<QsoRecord> dlg = new Dialog<>();
+        dlg.setTitle("Edit & Approve Record");
+        dlg.setHeaderText("Rejection reason: " + rejectionReason);
+        dlg.initOwner(parent);
+
+        ButtonType saveType = new ButtonType("Save", ButtonBar.ButtonData.OK_DONE);
+        dlg.getDialogPane().getButtonTypes().addAll(saveType, ButtonType.CANCEL);
+
+        TextField tfCall  = new TextField(safe(seed.getCallsign()));
+        TextField tfDate  = new TextField(seed.getDateTimeUtc() != null
+            ? seed.getDateTimeUtc().format(DT_PARSE) : "");
+        TextField tfBand  = new TextField(safe(seed.getBand()));
+        TextField tfMode  = new TextField(safe(seed.getMode()));
+        TextField tfFreq  = new TextField(safe(seed.getFrequency()));
+        TextField tfRstS  = new TextField(safe(seed.getRstSent()));
+        TextField tfRstR  = new TextField(safe(seed.getRstReceived()));
+        TextField tfCtry  = new TextField(safe(seed.getCountry()));
+        TextField tfName  = new TextField(safe(seed.getOperatorName()));
+        TextField tfState = new TextField(safe(seed.getState()));
+        TextField tfCnty  = new TextField(safe(seed.getCounty()));
+        TextField tfNotes = new TextField(safe(seed.getNotes()));
+
+        tfDate.setPromptText("yyyy-MM-dd HH:mm (UTC)");
+
+        GridPane grid = new GridPane();
+        grid.setHgap(8); grid.setVgap(6);
+        grid.setPadding(new Insets(10));
+        int row = 0;
+        grid.add(new Label("Callsign *"), 0, row); grid.add(tfCall,  1, row++);
+        grid.add(new Label("Date/Time"),  0, row); grid.add(tfDate,  1, row++);
+        grid.add(new Label("Band"),       0, row); grid.add(tfBand,  1, row++);
+        grid.add(new Label("Mode"),       0, row); grid.add(tfMode,  1, row++);
+        grid.add(new Label("Frequency"),  0, row); grid.add(tfFreq,  1, row++);
+        grid.add(new Label("RST Sent"),   0, row); grid.add(tfRstS,  1, row++);
+        grid.add(new Label("RST Rcvd"),   0, row); grid.add(tfRstR,  1, row++);
+        grid.add(new Label("Country"),    0, row); grid.add(tfCtry,  1, row++);
+        grid.add(new Label("Op Name"),    0, row); grid.add(tfName,  1, row++);
+        grid.add(new Label("State"),      0, row); grid.add(tfState, 1, row++);
+        grid.add(new Label("County"),     0, row); grid.add(tfCnty,  1, row++);
+        grid.add(new Label("Notes"),      0, row); grid.add(tfNotes, 1, row++);
+
+        dlg.getDialogPane().setContent(grid);
+
+        Node saveBtn = dlg.getDialogPane().lookupButton(saveType);
+        saveBtn.setDisable(tfCall.getText().trim().isEmpty());
+        tfCall.textProperty().addListener((o, oldv, newv) ->
+            saveBtn.setDisable(newv == null || newv.trim().isEmpty()));
+
+        dlg.setResultConverter(bt -> {
+            if (bt != saveType) return null;
+            QsoRecord q = new QsoRecord();
+            q.setCallsign(tfCall.getText());
+            q.setBand(tfBand.getText());
+            q.setMode(tfMode.getText());
+            q.setFrequency(tfFreq.getText());
+            q.setRstSent(tfRstS.getText());
+            q.setRstReceived(tfRstR.getText());
+            q.setCountry(tfCtry.getText());
+            q.setOperatorName(tfName.getText());
+            q.setState(tfState.getText());
+            q.setCounty(tfCnty.getText());
+            q.setNotes(tfNotes.getText());
+            String d = tfDate.getText() == null ? "" : tfDate.getText().trim();
+            if (!d.isEmpty()) {
+                try { q.setDateTimeUtc(LocalDateTime.parse(d, DT_PARSE)); }
+                catch (DateTimeParseException ignored) {}
+            }
+            return q;
+        });
+        return dlg.showAndWait().orElse(null);
+    }
+
+    private static String safe(String s) { return s == null ? "" : s; }
+}


### PR DESCRIPTION
## Summary

ADIF imports with rejections used to silently drop the failure list — the status bar showed "imported N, skipped M" and the operator had no way to see what was rejected or fix it. After a real import that produced many rejections, asked for a review surface plus the ability to approve fixed records into the DB.

## Engine refactor (AdifImporter)

- `Result.failures` changed from `List<String>` (reasons only) to `List<RejectedRecord>` with `{recordNumber, reason, fields, partial}`.
- Parser threads a 1-based record counter through; `applyRecord` captures the parsed `Map<String,String>` and the best-effort `QsoRecord` built so far so the UI can pre-populate an edit form.
- Existing `missingCallRecordIsRecordedAsFailure` test updated to assert the new shape (recordNumber=1, reason, parsed BAND/MODE fields, partial QsoRecord with band/mode but blank callsign).

## j-log UI

- New `RejectedQsosDialog` (`com.jlog.controller`) — non-modal Stage with a per-rejection `TableView` (#, reason, callsign, datetime, band, mode).
- Per-row **Edit & Approve** pops a modal editor pre-filled from the parsed fields with TextFields for the standard QSO columns (call required; date/time/band/mode/freq/RST/country/name/state/county/notes). Save inserts via `QsoDao` and removes the row. **Skip** drops the row without inserting.
- Both ADIF import success paths now open the dialog when `r.failed > 0`:
  - WebSocket-initiated from j-hub web UI (`NormalLogController:240`)
  - File-menu direct in j-log (`NormalLogController:1182`)
- Status bar now shows "imported N, skipped M, rejected K" so the operator sees the rejection count even before the dialog renders.

## Test plan
- [x] `mvn clean install` j-log-engine → 141/141 tests pass (including updated RejectedRecord assertion)
- [x] `mvn clean package` j-log → fat jar builds, `RejectedQsosDialog` + `AdifImporter$RejectedRecord` present in shaded classes
- [ ] Manual: import an ADIF file with at least one record missing CALL → dialog opens; Edit & Approve adds a callsign and the record lands in the log; Skip drops the row without an insert

## Out of scope
- "Save rejected to file" round-trip recovery — deferred per scope check earlier; the in-app editor covers the common case.
- Cross-process notification to j-hub web UI ("import done with N rejections") — the dialog opens in j-log directly regardless of which UI initiated the upload, so the operator sees the result either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)