### PR TITLE
j-log: keyer pane always visible — absorbs gap, macros always present

### DIFF
--- a/j-log/src/main/resources/com/jlog/fxml/NormalLog.fxml
+++ b/j-log/src/main/resources/com/jlog/fxml/NormalLog.fxml
@@ -36,6 +36,7 @@
                     <Menu text="Tools">
                         <items>
                             <CheckMenuItem fx:id="miToggleKeyer" text="CW / Digital Keyer"
+                                           selected="true"
                                            onAction="#toggleKeyerPane"/>
                             <SeparatorMenuItem/>
                             <MenuItem text="Override Antenna…"      onAction="#doAntennaOverride"/>
@@ -269,7 +270,7 @@
                  the full window width because it's a direct VBox child
                  (not inside the SplitPane). -->
             <VBox fx:id="keyerPane" spacing="4" styleClass="keyer-pane"
-                  visible="false" managed="false" minHeight="0" prefHeight="150">
+                  minHeight="0">
                 <padding><Insets top="4" right="6" bottom="4" left="6"/></padding>
                 <!-- Macro button bar (moved out of the top section so it
                      toggles with the keyer). MacroEngine populates it at


### PR DESCRIPTION
## Summary

Follow-up to PR #69. Operator noted gray space between the 4-pane info row and the QSO log split (where the keyer would appear if toggled, but empty by default). Also wanted the macros present all the time.

**Fix:** default the keyer pane to **visible**. `macroButtonBar` already lives inside the keyer pane (PR #69), so making the keyer permanent makes the macros permanent too — both in the same area just below the 4-pane info row, spanning full width.

## Changes
- `keyerPane`: dropped `visible="false" managed="false"` + `prefHeight=150` so it sizes naturally to its three rows (macros + keyer top row + TX row) and fills only as much of the gap as its content needs.
- `miToggleKeyer` (Tools menu CheckMenuItem): defaults to `selected="true"` so the menu state matches the new visible-by-default behavior. The toggle still works if anyone wants to hide it.

## Test plan
- [x] `mvn clean package` j-log → builds clean
- [ ] Manual: launch j-log Normal mode → no gray gap; macros + keyer fields visible just below info row; Tools → CW/Digital Keyer is checked by default and unchecking it still collapses the pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)