### PR TITLE
j-log: macros in the gap; pin keyer height so Heard-By can't collapse it

### DIFF
--- a/j-log/src/main/resources/com/jlog/fxml/NormalLog.fxml
+++ b/j-log/src/main/resources/com/jlog/fxml/NormalLog.fxml
@@ -266,18 +266,21 @@
          ============================================================ -->
     <center>
         <VBox>
-            <!-- CW / Digital keyer + macros. Hidden by default. Spans
-                 the full window width because it's a direct VBox child
-                 (not inside the SplitPane). -->
+            <!-- Macro button bar — always visible, lives in the gap
+                 between the 4-pane info row and the transmit/keyer
+                 pane. MacroEngine populates the buttons at init. -->
+            <HBox fx:id="macroButtonBar" styleClass="macro-bar" spacing="4">
+                <padding><Insets top="2" left="6" right="6" bottom="2"/></padding>
+            </HBox>
+
+            <!-- CW / Digital keyer (the "transmit pane"). Always visible
+                 (Tools menu toggle can hide it). minHeight=USE_PREF_SIZE
+                 so VBox can't collapse it to zero when the SplitPane
+                 below it wants more space (e.g. operator expands the
+                 Heard-By TitledPane in the right column). -->
             <VBox fx:id="keyerPane" spacing="4" styleClass="keyer-pane"
-                  minHeight="0">
+                  minHeight="-Infinity">
                 <padding><Insets top="4" right="6" bottom="4" left="6"/></padding>
-                <!-- Macro button bar (moved out of the top section so it
-                     toggles with the keyer). MacroEngine populates it at
-                     init time. -->
-                <HBox fx:id="macroButtonBar" styleClass="macro-bar" spacing="4">
-                    <padding><Insets top="2" bottom="2"/></padding>
-                </HBox>
                 <HBox spacing="6" alignment="CENTER_LEFT">
                     <Label text="Keyer:" styleClass="section-title"/>
                     <ComboBox fx:id="cbKeyerMode" prefWidth="90"/>

--- a/j-log/src/main/resources/com/jlog/fxml/NormalLog.fxml
+++ b/j-log/src/main/resources/com/jlog/fxml/NormalLog.fxml
@@ -36,6 +36,7 @@
                     <Menu text="Tools">
                         <items>
                             <CheckMenuItem fx:id="miToggleKeyer" text="CW / Digital Keyer"
+                                           selected="true"
                                            onAction="#toggleKeyerPane"/>
                             <SeparatorMenuItem/>
                             <MenuItem text="Override Antenna…"      onAction="#doAntennaOverride"/>
@@ -269,7 +270,7 @@
                  the full window width because it's a direct VBox child
                  (not inside the SplitPane). -->
             <VBox fx:id="keyerPane" spacing="4" styleClass="keyer-pane"
-                  visible="false" managed="false" minHeight="0" prefHeight="150">
+                  minHeight="0">
                 <padding><Insets top="4" right="6" bottom="4" left="6"/></padding>
                 <!-- Macro button bar (moved out of the top section so it
                      toggles with the keyer). MacroEngine populates it at


### PR DESCRIPTION
## Summary

Two follow-ups to PR #70:

### 1. Macros in the gap (not nested in keyer)
Operator wanted the macro buttons in the gray gap between the 4-pane info row and the transmit/keyer pane — not nested inside the keyer. Pulled `macroButtonBar` back out as a sibling above the keyer pane. Macros now always visible regardless of keyer toggle state.

### 2. Heard-By expansion no longer collapses the keyer
Operator reported: expanding the Heard-By TitledPane (inside the right column of `mainSplitPane`) was collapsing the keyer pane. Root cause: the keyer had `minHeight="0"` so VBox happily shrank it to zero when the SplitPane below it (`vgrow=ALWAYS`) wanted more space to honor Heard-By's prefHeight. Fix: change keyer `minHeight="-Infinity"` (JavaFX FXML form of `Region.USE_PREF_SIZE`) so the keyer sits at its computed pref-height as a floor; any space pressure from the SplitPane comes out of the SplitPane's own allocation instead.

## New center-pane order
```
<VBox>                        ← inside <center>
  macroButtonBar              ← always-visible, fills the gap
  keyerPane                   ← transmit/keyer area, min-height pinned
  mainSplitPane vgrow=ALWAYS  ← QSO log left + DX/HeardBy right
</VBox>
```

## Test plan
- [x] `mvn clean package` j-log builds clean
- [x] fx:ids unique, placement order correct (macros → keyer → SplitPane)
- [ ] Manual: launch j-log → macros visible in gap; expand Heard-By in right column → keyer pane stays at full height (no collapse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)