### PR TITLE
j-log: ADIF import DupeMode.REVIEW — per-row Keep/Overwrite/Skip

### DIFF
--- a/j-log-engine/src/main/java/com/jlog/db/QsoDao.java
+++ b/j-log-engine/src/main/java/com/jlog/db/QsoDao.java
@@ -150,6 +150,25 @@ public class QsoDao {
         return query("SELECT * FROM qso ORDER BY datetime_utc ASC");
     }
 
+    /** Rows that match the dupe key (callsign + band + mode). Returned in
+     *  insertion order. Used by AdifImporter's REVIEW dupe-mode so the
+     *  operator's review dialog can show the EXISTING row(s) next to the
+     *  incoming row before deciding Keep / Overwrite / Skip. */
+    public List<QsoRecord> findByDupeKey(String callsign, String band, String mode) throws SQLException {
+        String sql = "SELECT * FROM qso WHERE callsign=? AND band=? AND mode=? "
+                   + "ORDER BY id ASC";
+        try (PreparedStatement ps = conn().prepareStatement(sql)) {
+            ps.setString(1, callsign == null ? "" : callsign.toUpperCase().trim());
+            ps.setString(2, band == null ? "" : band);
+            ps.setString(3, mode == null ? "" : mode);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<QsoRecord> list = new ArrayList<>();
+                while (rs.next()) list.add(map(rs));
+                return list;
+            }
+        }
+    }
+
     /** All QSOs with this callsign (any band, any mode), newest-first.
      *  Used by the cockpit's live "Previous QSOs with &lt;CALL&gt;" panel —
      *  populates when the operator types into the callsign entry field. */

--- a/j-log-engine/src/main/java/com/jlog/export/AdifImporter.java
+++ b/j-log-engine/src/main/java/com/jlog/export/AdifImporter.java
@@ -34,7 +34,12 @@ public class AdifImporter {
 
     private static final Logger log = LoggerFactory.getLogger(AdifImporter.class);
 
-    public enum DupeMode { SKIP, OVERWRITE, APPEND }
+    /** What to do when an incoming record collides with an existing one
+     *  on the (callsign, band, mode) key. {@code REVIEW} is the
+     *  interactive variant — instead of acting silently on every dupe,
+     *  the importer collects them into {@link Result#duplicates} and
+     *  the UI opens a per-row review dialog after the import settles. */
+    public enum DupeMode { SKIP, OVERWRITE, APPEND, REVIEW }
 
     public static class Result {
         public int imported;
@@ -46,10 +51,15 @@ public class AdifImporter {
          *  {@code List<String>} of bare reason strings so the UI has the
          *  parsed fields available to populate an edit form. */
         public List<RejectedRecord> failures = new ArrayList<>();
+        /** Per-record duplicate-collision review queue — populated only
+         *  when {@link DupeMode#REVIEW} is used. The UI opens a separate
+         *  Review Duplicates dialog after the import settles so the
+         *  operator can pick Keep / Overwrite / Skip for each row. */
+        public List<DuplicateRecord> duplicates = new ArrayList<>();
 
         @Override public String toString() {
-            return String.format("imported=%d overwritten=%d skipped=%d failed=%d",
-                imported, overwritten, skipped, failed);
+            return String.format("imported=%d overwritten=%d skipped=%d failed=%d duplicates=%d",
+                imported, overwritten, skipped, failed, duplicates.size());
         }
     }
 
@@ -80,6 +90,27 @@ public class AdifImporter {
 
         @Override public String toString() {
             return "#" + recordNumber + ": " + reason;
+        }
+    }
+
+    /** One incoming record that collided with an existing log row.
+     *  Surfaced to the Review Duplicates dialog when DupeMode.REVIEW
+     *  is used. */
+    public static class DuplicateRecord {
+        public final int recordNumber;
+        /** Parsed-and-ready QsoRecord for the incoming row. */
+        public final QsoRecord incoming;
+        /** Existing rows that match the (callsign, band, mode) dupe
+         *  key in the DB right now. Usually exactly 1; can be &gt;1 if
+         *  earlier APPEND imports left genuine accumulated dupes. */
+        public final List<QsoRecord> existingMatches;
+
+        public DuplicateRecord(int recordNumber, QsoRecord incoming,
+                               List<QsoRecord> existingMatches) {
+            this.recordNumber    = recordNumber;
+            this.incoming        = incoming;
+            this.existingMatches = existingMatches == null
+                ? List.of() : List.copyOf(existingMatches);
         }
     }
 
@@ -204,6 +235,14 @@ public class AdifImporter {
                     QsoDao.getInstance().deleteByKey(q.getCallsign(), band, mode);
                     QsoDao.getInstance().insert(q);
                     r.overwritten++;
+                    return;
+                }
+                if (dupeMode == DupeMode.REVIEW) {
+                    // Defer the per-row decision to the UI's Review
+                    // Duplicates dialog. Don't touch the DB now.
+                    r.duplicates.add(new DuplicateRecord(
+                        recordNumber, q,
+                        QsoDao.getInstance().findByDupeKey(q.getCallsign(), band, mode)));
                     return;
                 }
                 // APPEND: fall through to the plain insert below.

--- a/j-log-engine/src/test/java/com/jlog/export/AdifImporterTest.java
+++ b/j-log-engine/src/test/java/com/jlog/export/AdifImporterTest.java
@@ -115,6 +115,42 @@ class AdifImporterTest {
         assertEquals(6, QsoDao.getInstance().count(), "APPEND legitimately duplicates");
     }
 
+    /**
+     * REVIEW mode: collisions go into r.duplicates instead of silently
+     * skipping/overwriting. DB is NOT modified for dupe rows (the UI
+     * dialog applies the operator's per-row Keep/Overwrite/Skip choice
+     * after the fact). Non-dupe rows still import normally.
+     */
+    @Test
+    void reviewModeCollectsDupesInsteadOfActing(@TempDir Path dir) throws Exception {
+        Path adif = writeAdif(dir, "review.adi");
+        AdifImporter.importAdif(adif, AdifImporter.DupeMode.SKIP);   // seed: 3 rows
+        int before = QsoDao.getInstance().count();
+        assertEquals(3, before);
+
+        AdifImporter.Result r = AdifImporter.importAdif(adif, AdifImporter.DupeMode.REVIEW);
+        assertEquals(0, r.imported,    "REVIEW must not insert dupes silently");
+        assertEquals(0, r.overwritten, "REVIEW must not overwrite dupes silently");
+        assertEquals(0, r.skipped,     "REVIEW counts dupes in r.duplicates, not r.skipped");
+        assertEquals(3, r.duplicates.size(),
+            "all 3 incoming rows collided and must surface in r.duplicates");
+        assertEquals(before, QsoDao.getInstance().count(),
+            "REVIEW must leave the DB unchanged for dupe rows");
+
+        // Each DuplicateRecord must carry the incoming QsoRecord +
+        // the existing DB row that matched (so the UI can show both).
+        for (AdifImporter.DuplicateRecord d : r.duplicates) {
+            assertTrue(d.incoming != null && d.incoming.getCallsign() != null
+                && !d.incoming.getCallsign().isBlank(),
+                "incoming QsoRecord must be parsed and have a callsign");
+            assertEquals(1, d.existingMatches.size(),
+                "each dupe must have exactly 1 existing match in this seed");
+            assertEquals(d.incoming.getCallsign(),
+                d.existingMatches.get(0).getCallsign().toUpperCase(),
+                "existing match must be on the same callsign");
+        }
+    }
+
     @Test
     void missingCallRecordIsRecordedAsFailure(@TempDir Path dir) throws Exception {
         Path adif = dir.resolve("bad.adi");

--- a/j-log/src/main/java/com/jlog/controller/NormalLogController.java
+++ b/j-log/src/main/java/com/jlog/controller/NormalLogController.java
@@ -1160,20 +1160,23 @@ public class NormalLogController implements Initializable {
         File f = fc.showOpenDialog(getStage());
         if (f == null) return;
 
-        // Three choices: Skip / Overwrite / Append
+        // Four choices: Skip / Append / Review / Cancel
         Alert dupeChoice = new Alert(Alert.AlertType.CONFIRMATION,
             "How should duplicates be handled?\n\n"
-          + "Skip — keep existing, drop incoming.\n"
+          + "Skip   — keep existing, drop incoming.\n"
           + "Append — insert all rows, even duplicates.\n"
+          + "Review — open a per-row Keep/Overwrite/Skip dialog after import.\n"
           + "Cancel — abort import.",
-            new ButtonType("Skip"), new ButtonType("Append"), ButtonType.CANCEL);
+            new ButtonType("Skip"), new ButtonType("Append"),
+            new ButtonType("Review"), ButtonType.CANCEL);
         dupeChoice.setHeaderText("Duplicate handling");
         ButtonType choice = dupeChoice.showAndWait().orElse(ButtonType.CANCEL);
         if (choice == ButtonType.CANCEL) return;
-        final com.jlog.export.AdifImporter.DupeMode mode =
-            "Append".equals(choice.getText())
-                ? com.jlog.export.AdifImporter.DupeMode.APPEND
-                : com.jlog.export.AdifImporter.DupeMode.SKIP;
+        final com.jlog.export.AdifImporter.DupeMode mode = switch (choice.getText()) {
+            case "Append" -> com.jlog.export.AdifImporter.DupeMode.APPEND;
+            case "Review" -> com.jlog.export.AdifImporter.DupeMode.REVIEW;
+            default       -> com.jlog.export.AdifImporter.DupeMode.SKIP;
+        };
 
         Task<com.jlog.export.AdifImporter.Result> task = new Task<>() {
             @Override protected com.jlog.export.AdifImporter.Result call() throws Exception {
@@ -1182,10 +1185,14 @@ public class NormalLogController implements Initializable {
             @Override protected void succeeded() {
                 var r = getValue();
                 setStatus("Imported " + r.imported + ", skipped " + r.skipped
-                          + ", failed " + r.failed);
+                    + ", failed " + r.failed
+                    + (r.duplicates.isEmpty() ? "" : ", duplicates " + r.duplicates.size()));
                 loadQsos();
                 if (r.failed > 0 && !r.failures.isEmpty()) {
                     RejectedQsosDialog.show(r.failures, () -> loadQsos());
+                }
+                if (!r.duplicates.isEmpty()) {
+                    ReviewDuplicatesDialog.show(r.duplicates, () -> loadQsos());
                 }
             }
             @Override protected void failed() { setStatus("Import failed: " + getException().getMessage()); }

--- a/j-log/src/main/java/com/jlog/controller/ReviewDuplicatesDialog.java
+++ b/j-log/src/main/java/com/jlog/controller/ReviewDuplicatesDialog.java
@@ -1,0 +1,209 @@
+package com.jlog.controller;
+
+import com.jlog.db.QsoDao;
+import com.jlog.export.AdifImporter;
+import com.jlog.model.QsoRecord;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.*;
+import javafx.scene.layout.*;
+import javafx.stage.Stage;
+import javafx.util.Callback;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Non-modal "Review Duplicates" dialog. Opens after an ADIF import that
+ * ran in {@link AdifImporter.DupeMode#REVIEW}. For each incoming record
+ * that collided with an existing log row on the (callsign, band, mode)
+ * dupe key, the operator picks:
+ *
+ *   Keep      — insert the incoming row as a new QSO (APPEND for this row)
+ *   Overwrite — delete the existing row and insert the incoming row
+ *   Skip      — drop the incoming row without changing the DB
+ *
+ * Bulk "Apply to All" buttons at the bottom run the chosen action over
+ * every remaining row. {@code onClose} fires when the operator dismisses
+ * the dialog so the main controller can refresh its QSO table.
+ */
+public final class ReviewDuplicatesDialog {
+
+    private static final DateTimeFormatter DT_DISPLAY =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    private ReviewDuplicatesDialog() {}
+
+    public static void show(List<AdifImporter.DuplicateRecord> duplicates, Runnable onClose) {
+        if (duplicates == null || duplicates.isEmpty()) {
+            if (onClose != null) onClose.run();
+            return;
+        }
+        Stage stage = new Stage();
+        stage.setTitle("Review Duplicates (" + duplicates.size() + ")");
+
+        ObservableList<AdifImporter.DuplicateRecord> data =
+            FXCollections.observableArrayList(duplicates);
+
+        TableView<AdifImporter.DuplicateRecord> table = new TableView<>(data);
+        table.setPlaceholder(new Label("All duplicates resolved — close this window."));
+
+        TableColumn<AdifImporter.DuplicateRecord, String> colNum = simpleCol(
+            "#", 50, d -> String.valueOf(d.recordNumber));
+        TableColumn<AdifImporter.DuplicateRecord, String> colCall = simpleCol(
+            "Callsign", 100, d -> safe(d.incoming.getCallsign()));
+        TableColumn<AdifImporter.DuplicateRecord, String> colDate = simpleCol(
+            "Incoming Date/Time", 140, d ->
+                d.incoming.getDateTimeUtc() != null
+                    ? d.incoming.getDateTimeUtc().format(DT_DISPLAY) : "");
+        TableColumn<AdifImporter.DuplicateRecord, String> colBand = simpleCol(
+            "Band", 60, d -> safe(d.incoming.getBand()));
+        TableColumn<AdifImporter.DuplicateRecord, String> colMode = simpleCol(
+            "Mode", 70, d -> safe(d.incoming.getMode()));
+        TableColumn<AdifImporter.DuplicateRecord, String> colExisting = simpleCol(
+            "Existing", 220, d -> {
+                if (d.existingMatches.isEmpty()) return "—";
+                QsoRecord first = d.existingMatches.get(0);
+                String dt = first.getDateTimeUtc() != null
+                    ? first.getDateTimeUtc().format(DT_DISPLAY) : "(no date)";
+                String extra = d.existingMatches.size() > 1
+                    ? " (+ " + (d.existingMatches.size() - 1) + " more)" : "";
+                return dt + extra;
+            });
+        TableColumn<AdifImporter.DuplicateRecord, Void> colAction = new TableColumn<>("Action");
+        colAction.setPrefWidth(260);
+        colAction.setCellFactory(actionCellFactory(data));
+
+        table.getColumns().addAll(colNum, colCall, colDate, colBand, colMode,
+                                  colExisting, colAction);
+
+        Label header = new Label(
+            "Per-row choices: Keep inserts the incoming record as a new QSO;\n"
+          + "Overwrite replaces the existing row(s); Skip drops the incoming row.\n"
+          + "The bulk buttons at the bottom apply your choice to every remaining row.");
+        header.setWrapText(true);
+        header.setPadding(new Insets(6, 8, 6, 8));
+
+        Button btnKeepAll      = new Button("Keep all");
+        Button btnOverwriteAll = new Button("Overwrite all");
+        Button btnSkipAll      = new Button("Skip all");
+        Button btnClose        = new Button("Close");
+        btnKeepAll.setOnAction(e -> bulk(stage, data, BulkAction.KEEP));
+        btnOverwriteAll.setOnAction(e -> bulk(stage, data, BulkAction.OVERWRITE));
+        btnSkipAll.setOnAction(e -> bulk(stage, data, BulkAction.SKIP));
+        btnClose.setOnAction(e -> stage.close());
+
+        HBox bulkBar = new HBox(8, btnKeepAll, btnOverwriteAll, btnSkipAll);
+        bulkBar.setAlignment(Pos.CENTER_LEFT);
+        HBox bottom = new HBox(8, bulkBar, spacer(), btnClose);
+        bottom.setAlignment(Pos.CENTER_LEFT);
+        bottom.setPadding(new Insets(8));
+
+        BorderPane root = new BorderPane();
+        root.setTop(header);
+        root.setCenter(table);
+        root.setBottom(bottom);
+
+        Scene scene = new Scene(root, 1040, 480);
+        stage.setScene(scene);
+        stage.setOnHiding(e -> { if (onClose != null) onClose.run(); });
+        stage.show();
+    }
+
+    // ---- per-row buttons -----------------------------------------------
+
+    private enum BulkAction { KEEP, OVERWRITE, SKIP }
+
+    private static Callback<TableColumn<AdifImporter.DuplicateRecord, Void>,
+                             TableCell<AdifImporter.DuplicateRecord, Void>>
+        actionCellFactory(ObservableList<AdifImporter.DuplicateRecord> data) {
+        return col -> new TableCell<>() {
+            private final Button keep      = new Button("Keep");
+            private final Button overwrite = new Button("Overwrite");
+            private final Button skip      = new Button("Skip");
+            private final HBox box = new HBox(6, keep, overwrite, skip);
+            {
+                box.setAlignment(Pos.CENTER);
+                keep.setOnAction(e -> applyRow(getRow(), data, BulkAction.KEEP, this));
+                overwrite.setOnAction(e -> applyRow(getRow(), data, BulkAction.OVERWRITE, this));
+                skip.setOnAction(e -> applyRow(getRow(), data, BulkAction.SKIP, this));
+            }
+            private AdifImporter.DuplicateRecord getRow() {
+                int idx = getIndex();
+                if (idx < 0 || idx >= getTableView().getItems().size()) return null;
+                return getTableView().getItems().get(idx);
+            }
+            @Override protected void updateItem(Void v, boolean empty) {
+                super.updateItem(v, empty);
+                setGraphic(empty ? null : box);
+            }
+        };
+    }
+
+    private static void applyRow(AdifImporter.DuplicateRecord rec,
+                                 ObservableList<AdifImporter.DuplicateRecord> data,
+                                 BulkAction action, Node ownerForAlerts) {
+        if (rec == null) return;
+        try {
+            switch (action) {
+                case KEEP      -> QsoDao.getInstance().insert(rec.incoming);
+                case OVERWRITE -> {
+                    String call = rec.incoming.getCallsign();
+                    String band = rec.incoming.getBand() == null ? "" : rec.incoming.getBand();
+                    String mode = rec.incoming.getMode() == null ? "" : rec.incoming.getMode();
+                    QsoDao.getInstance().deleteByKey(call, band, mode);
+                    QsoDao.getInstance().insert(rec.incoming);
+                }
+                case SKIP -> { /* no-op */ }
+            }
+            data.remove(rec);
+        } catch (Exception ex) {
+            Alert a = new Alert(Alert.AlertType.ERROR,
+                action + " failed: " + ex.getMessage(), ButtonType.OK);
+            a.setHeaderText("Could not apply choice");
+            a.showAndWait();
+        }
+    }
+
+    private static void bulk(Stage parent,
+                             ObservableList<AdifImporter.DuplicateRecord> data,
+                             BulkAction action) {
+        if (data.isEmpty()) return;
+        Alert confirm = new Alert(Alert.AlertType.CONFIRMATION,
+            action + " all " + data.size() + " remaining duplicate(s)?",
+            ButtonType.OK, ButtonType.CANCEL);
+        confirm.setHeaderText("Apply to all");
+        confirm.initOwner(parent);
+        if (confirm.showAndWait().orElse(ButtonType.CANCEL) != ButtonType.OK) return;
+
+        // Snapshot — applyRow mutates `data`.
+        for (AdifImporter.DuplicateRecord rec : List.copyOf(data)) {
+            applyRow(rec, data, action, parent.getScene().getRoot());
+        }
+    }
+
+    // ---- helpers --------------------------------------------------------
+
+    private static TableColumn<AdifImporter.DuplicateRecord, String>
+        simpleCol(String title, double width,
+                  java.util.function.Function<AdifImporter.DuplicateRecord, String> getter) {
+        TableColumn<AdifImporter.DuplicateRecord, String> c = new TableColumn<>(title);
+        c.setPrefWidth(width);
+        c.setCellValueFactory(cd -> new SimpleStringProperty(getter.apply(cd.getValue())));
+        c.setStyle("-fx-alignment: CENTER;");
+        return c;
+    }
+
+    private static Region spacer() {
+        Region r = new Region();
+        HBox.setHgrow(r, Priority.ALWAYS);
+        return r;
+    }
+
+    private static String safe(String s) { return s == null ? "" : s; }
+}


### PR DESCRIPTION
## Summary

Operator wanted a third option beyond "skip all dupes" and "add all dupes" — review each duplicate individually after the import runs. The existing Rejected QSOs dialog (PR #67) covers malformed records; this one covers `(callsign, band, mode)` collisions.

## Engine
- New `DupeMode.REVIEW` enum value. When set, `applyRecord` collects collisions into `r.duplicates` (`List<DuplicateRecord>`) instead of silently skipping/overwriting. **DB stays untouched** for dupe rows until the operator applies a per-row choice in the UI.
- New `DuplicateRecord {recordNumber, incoming, existingMatches}` carries the parsed incoming row plus whatever's already in the DB on the same dupe key so the dialog can show side-by-side context.
- New `QsoDao.findByDupeKey(callsign, band, mode)` — returns the existing rows for the `existingMatches` list. ORDER BY id ASC so the operator sees rows in their original insert order.
- `Result.toString` now includes `duplicates=` count.

## UI
- File → Import ADIF dupe picker grows a 4th button **Review** wired to `DupeMode.REVIEW`. Status bar after a REVIEW import shows `Imported N, skipped M, failed K, duplicates D`.
- New `ReviewDuplicatesDialog` (non-modal, similar shape to `RejectedQsosDialog`). One row per duplicate with columns: #, callsign, incoming date/time, band, mode, existing-row summary, action buttons. Per-row **Keep / Overwrite / Skip** plus bulk **Keep all / Overwrite all / Skip all** at the bottom.

## Tests
- New `reviewModeCollectsDupesInsteadOfActing`: seeds 3 rows via SKIP, re-imports same file in REVIEW mode, asserts `r.duplicates` has 3 entries, DB unchanged, each `DuplicateRecord` carries a parsed `incoming` + one `existingMatch` on the same callsign.
- 142/142 engine tests pass (was 141 + 1 new).

## Out of scope
- j-hub web UI's IMPORT_ADIF WebSocket path still hardcodes `DupeMode.SKIP`. Adding REVIEW there would need a way for the web UI to know the j-log dialog opened (or a separate review surface on the web side). Deferred until the operator needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)