### PR TITLE
j-log-engine: dupe key includes UTC date — same call/different-day != dupe

### DIFF
--- a/j-log-engine/src/main/java/com/jlog/db/QsoDao.java
+++ b/j-log-engine/src/main/java/com/jlog/db/QsoDao.java
@@ -120,26 +120,42 @@ public class QsoDao {
         }
     }
 
-    /** Delete every row matching the (callsign, band, mode) dupe key.
-     *  Returns the number of rows removed — typically 0 or 1, but can be
-     *  greater if past APPEND imports accumulated duplicates. */
-    public int deleteByKey(String callsign, String band, String mode) throws SQLException {
-        String sql = "DELETE FROM qso WHERE callsign=? AND band=? AND mode=?";
+    /** Delete every row matching the (callsign, band, mode, date) dupe key.
+     *  When {@code date} is null, falls back to the legacy (call, band, mode)
+     *  match — used for records that didn't carry a date so the operator
+     *  can still wipe them out by callsign/band/mode. Returns the number
+     *  of rows removed. */
+    public int deleteByKey(String callsign, String band, String mode,
+                           java.time.LocalDate date) throws SQLException {
+        String sql = (date == null)
+            ? "DELETE FROM qso WHERE callsign=? AND band=? AND mode=?"
+            : "DELETE FROM qso WHERE callsign=? AND band=? AND mode=? "
+            + "AND substr(datetime_utc, 1, 10)=?";
         try (PreparedStatement ps = conn().prepareStatement(sql)) {
             ps.setString(1, callsign == null ? "" : callsign.toUpperCase());
             ps.setString(2, band == null ? "" : band);
             ps.setString(3, mode == null ? "" : mode);
+            if (date != null) ps.setString(4, date.toString());
             return ps.executeUpdate();
         }
     }
 
-    /** Check for duplicate (same callsign + band + mode). */
-    public boolean isDuplicate(String callsign, String band, String mode) throws SQLException {
-        String sql = "SELECT COUNT(*) FROM qso WHERE callsign=? AND band=? AND mode=?";
+    /** Check for duplicate by the dupe key (callsign + band + mode + date).
+     *  Same call on different UTC days is NOT a duplicate (per the operator
+     *  rule "if dates are different it's not a dupe"). Same call+band+mode
+     *  on the same UTC day IS a duplicate. When {@code date} is null, falls
+     *  back to legacy (call, band, mode) match. */
+    public boolean isDuplicate(String callsign, String band, String mode,
+                               java.time.LocalDate date) throws SQLException {
+        String sql = (date == null)
+            ? "SELECT COUNT(*) FROM qso WHERE callsign=? AND band=? AND mode=?"
+            : "SELECT COUNT(*) FROM qso WHERE callsign=? AND band=? AND mode=? "
+            + "AND substr(datetime_utc, 1, 10)=?";
         try (PreparedStatement ps = conn().prepareStatement(sql)) {
-            ps.setString(1, callsign.toUpperCase());
-            ps.setString(2, band);
-            ps.setString(3, mode);
+            ps.setString(1, callsign == null ? "" : callsign.toUpperCase());
+            ps.setString(2, band == null ? "" : band);
+            ps.setString(3, mode == null ? "" : mode);
+            if (date != null) ps.setString(4, date.toString());
             ResultSet rs = ps.executeQuery();
             return rs.next() && rs.getInt(1) > 0;
         }
@@ -150,17 +166,22 @@ public class QsoDao {
         return query("SELECT * FROM qso ORDER BY datetime_utc ASC");
     }
 
-    /** Rows that match the dupe key (callsign + band + mode). Returned in
+    /** Rows that match the dupe key (callsign + band + mode + date) in
      *  insertion order. Used by AdifImporter's REVIEW dupe-mode so the
      *  operator's review dialog can show the EXISTING row(s) next to the
-     *  incoming row before deciding Keep / Overwrite / Skip. */
-    public List<QsoRecord> findByDupeKey(String callsign, String band, String mode) throws SQLException {
-        String sql = "SELECT * FROM qso WHERE callsign=? AND band=? AND mode=? "
-                   + "ORDER BY id ASC";
+     *  incoming row before deciding Keep / Overwrite / Skip. When
+     *  {@code date} is null, falls back to legacy (call, band, mode) match. */
+    public List<QsoRecord> findByDupeKey(String callsign, String band, String mode,
+                                         java.time.LocalDate date) throws SQLException {
+        String sql = (date == null)
+            ? "SELECT * FROM qso WHERE callsign=? AND band=? AND mode=? ORDER BY id ASC"
+            : "SELECT * FROM qso WHERE callsign=? AND band=? AND mode=? "
+            + "AND substr(datetime_utc, 1, 10)=? ORDER BY id ASC";
         try (PreparedStatement ps = conn().prepareStatement(sql)) {
             ps.setString(1, callsign == null ? "" : callsign.toUpperCase().trim());
             ps.setString(2, band == null ? "" : band);
             ps.setString(3, mode == null ? "" : mode);
+            if (date != null) ps.setString(4, date.toString());
             try (ResultSet rs = ps.executeQuery()) {
                 List<QsoRecord> list = new ArrayList<>();
                 while (rs.next()) list.add(map(rs));

--- a/j-log-engine/src/main/java/com/jlog/export/AdifImporter.java
+++ b/j-log-engine/src/main/java/com/jlog/export/AdifImporter.java
@@ -225,14 +225,18 @@ public class AdifImporter {
             }
             String band = q.getBand() == null ? "" : q.getBand();
             String mode = q.getMode() == null ? "" : q.getMode();
-            boolean dupe = QsoDao.getInstance().isDuplicate(q.getCallsign(), band, mode);
+            // Dupe key includes the QSO date — same call+band+mode on a
+            // different UTC day is a DIFFERENT contact. Operator rule.
+            java.time.LocalDate qDate = q.getDateTimeUtc() != null
+                ? q.getDateTimeUtc().toLocalDate() : null;
+            boolean dupe = QsoDao.getInstance().isDuplicate(q.getCallsign(), band, mode, qDate);
             if (dupe) {
                 if (dupeMode == DupeMode.SKIP) {
                     r.skipped++;
                     return;
                 }
                 if (dupeMode == DupeMode.OVERWRITE) {
-                    QsoDao.getInstance().deleteByKey(q.getCallsign(), band, mode);
+                    QsoDao.getInstance().deleteByKey(q.getCallsign(), band, mode, qDate);
                     QsoDao.getInstance().insert(q);
                     r.overwritten++;
                     return;
@@ -242,7 +246,7 @@ public class AdifImporter {
                     // Duplicates dialog. Don't touch the DB now.
                     r.duplicates.add(new DuplicateRecord(
                         recordNumber, q,
-                        QsoDao.getInstance().findByDupeKey(q.getCallsign(), band, mode)));
+                        QsoDao.getInstance().findByDupeKey(q.getCallsign(), band, mode, qDate)));
                     return;
                 }
                 // APPEND: fall through to the plain insert below.

--- a/j-log-engine/src/test/java/com/jlog/export/AdifImporterTest.java
+++ b/j-log-engine/src/test/java/com/jlog/export/AdifImporterTest.java
@@ -116,6 +116,35 @@ class AdifImporterTest {
     }
 
     /**
+     * Pins the 2026-05-29 operator rule: same callsign + band + mode on
+     * DIFFERENT UTC dates is NOT a duplicate. SKIP mode used to drop
+     * legitimate re-contacts on a later day; now they import.
+     */
+    @Test
+    void sameCallBandModeDifferentDateIsNotADupe(@TempDir Path dir) throws Exception {
+        // Seed: same record set as SAMPLE_ADIF (3 QSOs on 2026-01-01).
+        Path seed = writeAdif(dir, "seed.adi");
+        AdifImporter.importAdif(seed, AdifImporter.DupeMode.SKIP);
+        assertEquals(3, QsoDao.getInstance().count());
+
+        // Same 3 callsigns on the same bands/modes but a DIFFERENT day.
+        Path next = dir.resolve("nextday.adi");
+        Files.writeString(next, """
+                Header
+                <ADIF_VER:5>3.1.4
+                <EOH>
+                <CALL:5>K1ABC<BAND:3>20m<MODE:2>CW<QSO_DATE:8>20260102<TIME_ON:4>1300<EOR>
+                <CALL:5>JA1XY<BAND:3>15m<MODE:3>SSB<QSO_DATE:8>20260102<TIME_ON:4>1330<EOR>
+                <CALL:4>DL5Z<BAND:3>40m<MODE:3>FT8<QSO_DATE:8>20260102<TIME_ON:4>1345<EOR>
+                """);
+        AdifImporter.Result r = AdifImporter.importAdif(next, AdifImporter.DupeMode.SKIP);
+        assertEquals(3, r.imported, "different-day QSOs must NOT be flagged as duplicates");
+        assertEquals(0, r.skipped,  "different-day QSOs must not be skipped");
+        assertEquals(6, QsoDao.getInstance().count(),
+            "both days' contacts must coexist in the log");
+    }
+
+    /**
      * REVIEW mode: collisions go into r.duplicates instead of silently
      * skipping/overwriting. DB is NOT modified for dupe rows (the UI
      * dialog applies the operator's per-row Keep/Overwrite/Skip choice

--- a/j-log/src/main/java/com/jlog/controller/ReviewDuplicatesDialog.java
+++ b/j-log/src/main/java/com/jlog/controller/ReviewDuplicatesDialog.java
@@ -156,7 +156,9 @@ public final class ReviewDuplicatesDialog {
                     String call = rec.incoming.getCallsign();
                     String band = rec.incoming.getBand() == null ? "" : rec.incoming.getBand();
                     String mode = rec.incoming.getMode() == null ? "" : rec.incoming.getMode();
-                    QsoDao.getInstance().deleteByKey(call, band, mode);
+                    java.time.LocalDate date = rec.incoming.getDateTimeUtc() != null
+                        ? rec.incoming.getDateTimeUtc().toLocalDate() : null;
+                    QsoDao.getInstance().deleteByKey(call, band, mode, date);
                     QsoDao.getInstance().insert(rec.incoming);
                 }
                 case SKIP -> { /* no-op */ }


### PR DESCRIPTION
## Summary

Operator pointed out the long-standing dupe rule was wrong: same callsign + band + mode logged on a DIFFERENT UTC date was being flagged as a duplicate, so `SKIP` mode would silently drop legitimate re-contacts on later days. (Same file imported twice was the intended dupe; same station worked again on a different day is not.)

## Engine
- `QsoDao.isDuplicate`, `deleteByKey`, and `findByDupeKey` now take a `LocalDate` alongside `(callsign, band, mode)`. The SQL compares `substr(datetime_utc, 1, 10)` against the date string. When the caller passes `null` (date unknown), the methods fall back to the legacy `(call, band, mode)` match so dateless records still behave predictably.
- `AdifImporter.applyRecord` extracts `qDate` from the parsed QsoRecord's `datetime_utc` and threads it into all three calls.

## j-log
- `ReviewDuplicatesDialog`'s OVERWRITE branch extracts the date from `rec.incoming.dateTimeUtc` and passes it through `deleteByKey` so the replacement targets the correct day's row(s) instead of nuking every row matching call/band/mode across all dates.

## Tests
- New `sameCallBandModeDifferentDateIsNotADupe`: seeds 3 QSOs on 2026-01-01, re-imports the same callsigns/bands/modes dated 2026-01-02 under `SKIP`, asserts all 3 import (not skipped) and the log holds 6 rows.
- 143/143 engine tests pass (was 142 + 1).

Other tests still pass because they re-import the same file (same dates) — the dupe key behavior for that scenario is unchanged.

## Out of scope
- `ContestQsoDao`'s contest-specific dupe variants (per-band, per-mode, contest-wide, band+grid) — those follow per-contest sponsor rules and shouldn't be conflated with the operator's general-log rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)