### PR TITLE
j-log: split Data Entry row, add Rig Control placeholder pane on the right

### DIFF
--- a/j-log/src/main/resources/com/jlog/fxml/NormalLog.fxml
+++ b/j-log/src/main/resources/com/jlog/fxml/NormalLog.fxml
@@ -83,8 +83,13 @@
             </HBox>
 
             <!-- ============================================================
-                 ROW 2: DATA ENTRY PANE
+                 ROW 2: DATA ENTRY (left) + RIG CONTROL (right) — draggable
+                 horizontal split. Initial divider at 0.78 leaves enough
+                 width for the 12-column entry grid; the operator can drag
+                 the divider to give the rig pane more room when needed.
                  ============================================================ -->
+            <SplitPane orientation="HORIZONTAL" dividerPositions="0.78"
+                       styleClass="entry-split">
             <TitledPane text="%pane.entry" collapsible="false" styleClass="entry-pane">
                 <GridPane hgap="8" vgap="6" styleClass="entry-grid">
                     <padding><Insets top="8" left="10" right="10" bottom="8"/></padding>
@@ -153,6 +158,23 @@
                            GridPane.columnSpan="12" maxWidth="Infinity"/>
                 </GridPane>
             </TitledPane>
+
+            <!-- Rig Control pane — placeholder for now. Future content
+                 (Tier 1 display + Use Rig Freq button) will read
+                 RIG_STATUS from HubEngine and send RIG_COMMAND back
+                 via WebSocket. j-log stays interface-only; serial
+                 ownership stays in j-hub. -->
+            <TitledPane fx:id="rigControlPane" text="Rig Control"
+                        collapsible="false" styleClass="entry-pane">
+                <VBox spacing="6" alignment="CENTER">
+                    <padding><Insets top="10" right="10" bottom="10" left="10"/></padding>
+                    <Label text="Rig control coming soon."
+                           style="-fx-text-fill: #888; -fx-font-style: italic;"/>
+                    <Label text="Drag the divider to size this pane."
+                           style="-fx-text-fill: #888; -fx-font-size: 0.85em;"/>
+                </VBox>
+            </TitledPane>
+            </SplitPane>
 
             <!-- Macro button bar moved into the keyer pane (toggled with it). -->
 


### PR DESCRIPTION
## Summary

Operator wants room on the right side of the Data Entry row for a future Rig Control pane. Wrapped the existing entry `TitledPane` in a horizontal `SplitPane` and added a placeholder `TitledPane` to its right with a "coming soon" label. Divider starts at 0.78 (entry gets ~78% of width, rig pane ~22%) and is **draggable**.

## Why placeholder

Per the operator's architectural agreement ("j-log is interface only, it comms through j-hub"), the rig control pane will:
- Subscribe to `RIG_STATUS` via `HubEngine` (already wired)
- Send `RIG_COMMAND` WebSocket messages back to j-hub
- **Never talk to rigctld directly** — serial-port ownership stays in j-hub per the rig control architecture (memory: `project_managed_rigctld`)

This PR just carves out the layout space so the operator can confirm the fit before I build the Tier 1 content (display + Use Rig Freq button).

## Known cosmetic risk

Row 2 of the entry GridPane (Notes + QSL checkboxes + Save/Clear/Lookup buttons) may look cramped at 78% width. If it does, follow-up PR will re-flow the fields. Operator can also just drag the divider to give the entry pane more space.

## Test plan
- [x] `mvn clean package` j-log builds clean
- [x] fx:ids unique (`rigControlPane` is new)
- [ ] Manual: launch j-log → entry row now has Data Entry on left + Rig Control placeholder on right; divider draggable; row 2 of the entry grid still readable (or report if cramped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)